### PR TITLE
Skip tileentity ticks and reimplemented material for blocks

### DIFF
--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -52,7 +52,7 @@
  import net.minecraft.server.management.PlayerList;
  import net.minecraft.server.management.PlayerProfileCache;
  import net.minecraft.util.IProgressUpdate;
-@@ -73,35 +79,49 @@
+@@ -73,35 +79,50 @@
  import net.minecraft.world.MinecraftException;
  import net.minecraft.world.ServerWorldEventHandler;
  import net.minecraft.world.World;
@@ -82,6 +82,7 @@
 +import org.spigotmc.SlackActivityAccountant;
 +import red.mohist.common.RealTimeTicking;
 +import red.mohist.configuration.MohistConfig;
++import red.mohist.configuration.TileEntityConfig;
 +import red.mohist.forge.ForgeInjectBukkit;
 +import red.mohist.util.i18n.Message;
  
@@ -108,7 +109,7 @@
      @SideOnly(Side.SERVER)
      private String hostname;
      private int serverPort = -1;
-@@ -128,7 +148,6 @@
+@@ -128,7 +149,6 @@
      private KeyPair serverKeyPair;
      private String serverOwner;
      private String folderName;
@@ -116,7 +117,7 @@
      private String worldName;
      private boolean isDemo;
      private boolean enableBonusChest;
-@@ -144,26 +163,78 @@
+@@ -144,26 +164,80 @@
      private final GameProfileRepository profileRepo;
      private final PlayerProfileCache profileCache;
      private long nanoTimeSinceStatusRefresh;
@@ -150,6 +151,7 @@
 -    public MinecraftServer(File anvilFileIn, Proxy proxyIn, DataFixer dataFixerIn, YggdrasilAuthenticationService authServiceIn, MinecraftSessionService sessionServiceIn, GameProfileRepository profileRepoIn, PlayerProfileCache profileCacheIn)
 +    // Mohist start
 +    public static MohistConfig mohistConfig;
++    public static TileEntityConfig tileEntityConfig;
 +    private static long lastTickNanos = System.nanoTime();
 +    private static long realTimeTicks = 1;
 +    // Mohist end
@@ -170,6 +172,7 @@
          this.dataFixer = dataFixerIn;
 +        this.options = options;
 +        mohistConfig = new MohistConfig();
++        tileEntityConfig = new TileEntityConfig();
 +        // Try to see if we're actually running in a terminal, disable jline if not
 +        if (System.console() == null && System.getProperty("jline.terminal") == null) {
 +            System.setProperty("jline.terminal", "jline.UnsupportedTerminal");
@@ -200,7 +203,7 @@
      public ServerCommandManager createCommandManager()
      {
          return new ServerCommandManager(this);
-@@ -221,97 +292,96 @@
+@@ -221,97 +295,96 @@
  
      public void loadAllWorlds(String saveName, String worldNameIn, long seed, WorldType type, String generatorOptions)
      {
@@ -362,7 +365,7 @@
      }
  
      public void initialWorldChunkLoad()
-@@ -323,9 +393,12 @@
+@@ -323,9 +396,12 @@
          int i1 = 0;
          this.setUserMessage("menu.generatingTerrain");
          int j1 = 0;
@@ -376,7 +379,7 @@
          long k1 = getCurrentTimeMillis();
  
          for (int l1 = -192; l1 <= 192 && this.isServerRunning(); l1 += 16)
-@@ -336,7 +409,7 @@
+@@ -336,7 +412,7 @@
  
                  if (j2 - k1 > 1000L)
                  {
@@ -385,7 +388,7 @@
                      k1 = j2;
                  }
  
-@@ -345,6 +418,10 @@
+@@ -345,6 +421,10 @@
              }
          }
  
@@ -396,7 +399,7 @@
          this.clearCurrentTask();
      }
  
-@@ -394,13 +471,13 @@
+@@ -394,13 +474,13 @@
  
      public void saveAllWorlds(boolean isSilent)
      {
@@ -412,7 +415,7 @@
                  }
  
                  try
-@@ -415,10 +492,22 @@
+@@ -415,10 +495,22 @@
          }
      }
  
@@ -438,7 +441,7 @@
          if (this.getNetworkSystem() != null)
          {
              this.getNetworkSystem().terminateEndpoints();
-@@ -426,14 +515,15 @@
+@@ -426,14 +518,15 @@
  
          if (this.playerList != null)
          {
@@ -456,7 +459,7 @@
  
              for (WorldServer worldserver : this.worlds)
              {
-@@ -443,9 +533,12 @@
+@@ -443,9 +536,12 @@
                  }
              }
  
@@ -471,7 +474,7 @@
              {
                  if (worldserver1 != null)
                  {
-@@ -453,11 +546,12 @@
+@@ -453,11 +549,12 @@
                      worldserver1.flush();
                  }
              }
@@ -485,7 +488,7 @@
              }
          }
  
-@@ -467,6 +561,12 @@
+@@ -467,6 +564,12 @@
          }
  
          CommandBase.setCommandListener(null); // Forge: fix MC-128561
@@ -498,7 +501,7 @@
      }
  
      public boolean isServerRunning()
-@@ -479,74 +579,72 @@
+@@ -479,74 +582,72 @@
          this.serverRunning = false;
      }
  
@@ -606,7 +609,7 @@
              CrashReport crashreport = null;
  
              if (throwable1 instanceof ReportedException)
-@@ -555,21 +653,21 @@
+@@ -555,21 +656,21 @@
              }
              else
              {
@@ -632,7 +635,7 @@
              this.finalTick(crashreport);
          }
          finally
-@@ -580,12 +678,18 @@
+@@ -580,12 +681,18 @@
              }
              catch (Throwable throwable)
              {
@@ -652,7 +655,7 @@
                  this.systemExitNow();
              }
          }
-@@ -607,8 +711,11 @@
+@@ -607,8 +714,11 @@
              try
              {
                  BufferedImage bufferedimage = ImageIO.read(file1);
@@ -666,7 +669,7 @@
                  ImageIO.write(bufferedimage, "PNG", new ByteBufOutputStream(bytebuf));
                  ByteBuf bytebuf1 = Base64.encode(bytebuf);
                  response.setFavicon("data:image/png;base64," + bytebuf1.toString(StandardCharsets.UTF_8));
-@@ -616,7 +723,7 @@
+@@ -616,7 +726,7 @@
              }
              catch (Exception exception)
              {
@@ -675,7 +678,7 @@
              }
              finally
              {
-@@ -651,10 +758,18 @@
+@@ -651,10 +761,18 @@
      {
      }
  
@@ -697,7 +700,7 @@
          ++this.tickCounter;
  
          if (this.startProfiling)
-@@ -671,7 +786,7 @@
+@@ -671,7 +789,7 @@
          {
              this.nanoTimeSinceStatusRefresh = i;
              this.statusResponse.setPlayers(new ServerStatusResponse.Players(this.getMaxPlayers(), this.getCurrentPlayerCount()));
@@ -706,7 +709,7 @@
              int j = MathHelper.getInt(this.random, 0, this.getCurrentPlayerCount() - agameprofile.length);
  
              for (int k = 0; k < agameprofile.length; ++k)
-@@ -683,15 +798,17 @@
+@@ -683,15 +801,17 @@
              this.statusResponse.getPlayers().setPlayers(agameprofile);
              this.statusResponse.invalidateJson();
          }
@@ -726,7 +729,7 @@
          this.profiler.startSection("tallying");
          this.tickTimeArray[this.tickCounter % 100] = System.nanoTime() - i;
          this.profiler.endSection();
-@@ -710,94 +827,125 @@
+@@ -710,94 +830,125 @@
          this.profiler.endSection();
          this.profiler.endSection();
          net.minecraftforge.fml.common.FMLCommonHandler.instance().onPostServerTick();
@@ -905,7 +908,7 @@
  
          this.profiler.endSection();
      }
-@@ -809,9 +957,11 @@
+@@ -809,9 +960,11 @@
  
      public void startServerThread()
      {
@@ -917,7 +920,7 @@
      }
  
      public File getFile(String fileName)
-@@ -826,13 +976,13 @@
+@@ -826,13 +979,13 @@
  
      public WorldServer getWorld(int dimension)
      {
@@ -935,7 +938,7 @@
      }
  
      public String getMinecraftVersion()
-@@ -862,7 +1012,7 @@
+@@ -862,7 +1015,7 @@
  
      public String getServerModName()
      {
@@ -944,7 +947,7 @@
      }
  
      public CrashReport addServerInfoToCrashReport(CrashReport report)
-@@ -891,7 +1041,7 @@
+@@ -891,7 +1044,7 @@
  
      public List<String> getTabCompletions(ICommandSender sender, String input, @Nullable BlockPos pos, boolean hasTargetBlock)
      {
@@ -953,7 +956,7 @@
          boolean flag = input.startsWith("/");
  
          if (flag)
-@@ -908,11 +1058,9 @@
+@@ -908,11 +1061,9 @@
              {
                  if (CommandBase.doesStringStartWith(s2, s1))
                  {
@@ -966,7 +969,7 @@
          }
          else
          {
-@@ -925,27 +1073,29 @@
+@@ -925,27 +1076,29 @@
                  {
                      if (flag1 && !hasTargetBlock)
                      {
@@ -1002,7 +1005,7 @@
      }
  
      public void sendMessage(ITextComponent component)
-@@ -958,6 +1108,11 @@
+@@ -958,6 +1111,11 @@
          return true;
      }
  
@@ -1014,7 +1017,7 @@
      public ICommandManager getCommandManager()
      {
          return this.commandManager;
-@@ -993,13 +1148,11 @@
+@@ -993,13 +1151,11 @@
          this.folderName = name;
      }
  
@@ -1028,7 +1031,7 @@
      public String getWorldName()
      {
          return this.worldName;
-@@ -1012,7 +1165,7 @@
+@@ -1012,7 +1168,7 @@
  
      public void setDifficultyForAllWorlds(EnumDifficulty difficulty)
      {
@@ -1037,7 +1040,7 @@
          {
              if (worldserver1 != null)
              {
-@@ -1094,9 +1247,9 @@
+@@ -1094,9 +1250,9 @@
          playerSnooper.addClientStat("avg_tick_ms", Integer.valueOf((int)(MathHelper.average(this.tickTimeArray) * 1.0E-6D)));
          int l = 0;
  
@@ -1049,7 +1052,7 @@
              {
                  if (worldserver1 != null)
                  {
-@@ -1134,7 +1287,8 @@
+@@ -1134,7 +1290,8 @@
  
      public boolean isServerInOnlineMode()
      {
@@ -1059,7 +1062,7 @@
      }
  
      public void setOnlineMode(boolean online)
-@@ -1228,7 +1382,7 @@
+@@ -1228,7 +1385,7 @@
  
      public void setGameType(GameType gameMode)
      {
@@ -1068,7 +1071,7 @@
          {
              worldserver1.getWorldInfo().setGameType(gameMode);
          }
-@@ -1331,7 +1485,7 @@
+@@ -1331,7 +1488,7 @@
      @Nullable
      public Entity getEntityFromUuid(UUID uuid)
      {
@@ -1077,7 +1080,7 @@
          {
              if (worldserver1 != null)
              {
-@@ -1357,6 +1511,11 @@
+@@ -1357,6 +1514,11 @@
          return this;
      }
  
@@ -1089,7 +1092,7 @@
      public int getMaxWorldSize()
      {
          return 29999984;
-@@ -1366,15 +1525,14 @@
+@@ -1366,15 +1528,14 @@
      {
          Validate.notNull(callable);
  
@@ -1110,7 +1113,7 @@
          }
          else
          {
-@@ -1455,134 +1613,41 @@
+@@ -1455,134 +1616,41 @@
      }
  
      @SideOnly(Side.SERVER)
@@ -1261,7 +1264,7 @@
          }
      }
  
-@@ -1595,7 +1660,8 @@
+@@ -1595,7 +1663,8 @@
      @SideOnly(Side.SERVER)
      public boolean isDebuggingEnabled()
      {
@@ -1271,7 +1274,7 @@
      }
  
      @SideOnly(Side.SERVER)
-@@ -1659,4 +1725,9 @@
+@@ -1659,4 +1728,9 @@
      {
          return this.dataFixer;
      }

--- a/patches/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/net/minecraft/tileentity/TileEntity.java.patch
@@ -8,7 +8,7 @@
  import net.minecraft.nbt.NBTTagCompound;
  import net.minecraft.network.play.server.SPacketUpdateTileEntity;
  import net.minecraft.util.Mirror;
-@@ -16,20 +17,27 @@
+@@ -16,26 +17,38 @@
  import net.minecraft.util.registry.RegistryNamespaced;
  import net.minecraft.util.text.ITextComponent;
  import net.minecraft.world.World;
@@ -37,7 +37,18 @@
  
      public static void register(String id, Class <? extends TileEntity > clazz)
      {
-@@ -531,4 +539,30 @@
+         REGISTRY.putObject(new ResourceLocation(id), clazz);
+     }
+ 
++    public static RegistryNamespaced getRegisteredTileEntities()
++    {
++        return REGISTRY;
++    }
++
+     @Nullable
+     public static ResourceLocation getKey(Class <? extends TileEntity > clazz)
+     {
+@@ -531,4 +544,30 @@
          register("shulker_box", TileEntityShulkerBox.class);
          register("bed", TileEntityBed.class);
      }

--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -44,7 +44,7 @@
  import net.minecraft.pathfinding.PathWorldListener;
  import net.minecraft.profiler.Profiler;
  import net.minecraft.scoreboard.Scoreboard;
-@@ -52,17 +61,35 @@
+@@ -52,17 +61,36 @@
  import net.minecraft.village.VillageCollection;
  import net.minecraft.world.biome.Biome;
  import net.minecraft.world.biome.BiomeProvider;
@@ -77,10 +77,11 @@
 +import red.mohist.common.RealTimeTicking;
 +import red.mohist.common.cache.WorldCache;
 +import red.mohist.configuration.MohistConfig;
++import red.mohist.configuration.TileEntityWorldConfig;
  
  public abstract class World implements IBlockAccess, net.minecraftforge.common.capabilities.ICapabilityProvider
  {
-@@ -94,24 +121,24 @@
+@@ -94,24 +122,24 @@
      public float thunderingStrength;
      private int lastLightningBolt;
      public final Random rand = new Random();
@@ -112,7 +113,7 @@
      private boolean processingLoadedTiles;
      private final WorldBorder worldBorder;
      int[] lightUpdateBlockList;
-@@ -122,8 +149,110 @@
+@@ -122,8 +150,114 @@
      private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
      private net.minecraftforge.common.util.WorldCapabilityData capabilityData;
  
@@ -131,6 +132,8 @@
 +    public static boolean haveWeSilencedAPhysicsCrash;
 +    public static String blockLocation;
 +    public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions
++
++    public TileEntityWorldConfig tileentityConfig;
 +
 +    public CraftWorld getWorld() {
 +        return this.world;
@@ -165,6 +168,7 @@
 +        this.worldBorder = providerIn.createWorldBorder();
 +        perWorldStorage = new MapStorage((ISaveHandler)null);
 +        // Mohist start
++        this.tileentityConfig = new TileEntityWorldConfig(info.getWorldName(), MinecraftServer.tileEntityConfig);
 +        if(this.worldInfo != null) // Use saved dimension from level.dat. Fixes issues with MultiVerse
 +        {
 +            if (this.worldInfo.getDimension() != 0)
@@ -219,11 +223,12 @@
      protected World(ISaveHandler saveHandlerIn, WorldInfo info, WorldProvider providerIn, Profiler profilerIn, boolean client)
      {
 +        this.spigotConfig = new org.spigotmc.SpigotWorldConfig( info.getWorldName() ); // Spigot
++        this.tileentityConfig = new TileEntityWorldConfig(info.getWorldName(), MinecraftServer.tileEntityConfig);
 +        this.world = DimensionManager.getWorld(0) != null ? DimensionManager.getWorld(0).getWorld() : null;
          this.eventListeners = Lists.newArrayList(this.pathListener);
          this.calendar = Calendar.getInstance();
          this.worldScoreboard = new Scoreboard();
-@@ -137,6 +266,7 @@
+@@ -137,6 +271,7 @@
          this.isRemote = client;
          this.worldBorder = providerIn.createWorldBorder();
          perWorldStorage = new MapStorage((ISaveHandler)null);
@@ -231,7 +236,7 @@
      }
  
      public World init()
-@@ -298,7 +428,7 @@
+@@ -298,7 +433,7 @@
          }
      }
  
@@ -240,7 +245,7 @@
  
      public Chunk getChunkFromBlockCoords(BlockPos pos)
      {
-@@ -317,6 +447,26 @@
+@@ -317,6 +452,26 @@
  
      public boolean setBlockState(BlockPos pos, IBlockState newState, int flags)
      {
@@ -267,7 +272,7 @@
          if (this.isOutsideBuildHeight(pos))
          {
              return false;
-@@ -437,6 +587,11 @@
+@@ -437,6 +592,11 @@
      {
          if (this.worldInfo.getTerrainType() != WorldType.DEBUG_ALL_BLOCK_STATES)
          {
@@ -279,7 +284,7 @@
              this.notifyNeighborsOfStateChange(pos, blockType, p_175722_3_);
          }
      }
-@@ -488,7 +643,6 @@
+@@ -488,7 +648,6 @@
      {
          if(net.minecraftforge.event.ForgeEventFactory.onNeighborNotify(this, pos, this.getBlockState(pos), java.util.EnumSet.allOf(EnumFacing.class), updateObservers).isCanceled())
              return;
@@ -287,7 +292,7 @@
          this.neighborChanged(pos.west(), blockType, pos);
          this.neighborChanged(pos.east(), blockType, pos);
          this.neighborChanged(pos.down(), blockType, pos);
-@@ -548,6 +702,15 @@
+@@ -548,6 +707,15 @@
  
              try
              {
@@ -303,7 +308,7 @@
                  iblockstate.neighborChanged(this, pos, blockIn, fromPos);
              }
              catch (Throwable throwable)
-@@ -586,6 +749,11 @@
+@@ -586,6 +754,11 @@
                  {
                      iblockstate.getBlock().observedNeighborChange(iblockstate, this, pos, p_190529_2_, p_190529_3_);
                  }
@@ -315,7 +320,7 @@
                  catch (Throwable throwable)
                  {
                      CrashReport crashreport = CrashReport.makeCrashReport(throwable, "Exception while updating neighbours");
-@@ -596,7 +764,7 @@
+@@ -596,7 +769,7 @@
                          {
                              try
                              {
@@ -324,7 +329,7 @@
                              }
                              catch (Throwable var2)
                              {
-@@ -664,7 +832,6 @@
+@@ -664,7 +837,6 @@
              {
                  pos = new BlockPos(pos.getX(), 255, pos.getZ());
              }
@@ -332,7 +337,7 @@
              return this.getChunkFromBlockCoords(pos).getLightSubtracted(pos, 0);
          }
      }
-@@ -793,7 +960,7 @@
+@@ -793,7 +965,7 @@
              }
  
              if (!this.isValid(pos))
@@ -341,7 +346,7 @@
                  return type.defaultLightValue;
              }
              else if (!this.isBlockLoaded(pos))
-@@ -846,7 +1013,7 @@
+@@ -846,7 +1018,7 @@
          }
  
          if (!this.isValid(pos))
@@ -350,7 +355,7 @@
              return type.defaultLightValue;
          }
          else if (!this.isBlockLoaded(pos))
-@@ -863,7 +1030,7 @@
+@@ -863,7 +1035,7 @@
      public void setLightFor(EnumSkyBlock type, BlockPos pos, int lightValue)
      {
          if (this.isValid(pos))
@@ -359,7 +364,7 @@
              if (this.isBlockLoaded(pos))
              {
                  Chunk chunk = this.getChunkFromBlockCoords(pos);
-@@ -902,6 +1069,17 @@
+@@ -902,6 +1074,17 @@
  
      public IBlockState getBlockState(BlockPos pos)
      {
@@ -377,7 +382,7 @@
          if (this.isOutsideBuildHeight(pos))
          {
              return Blocks.AIR.getDefaultState();
-@@ -1181,14 +1359,66 @@
+@@ -1181,14 +1364,66 @@
  
      public boolean spawnEntity(Entity entityIn)
      {
@@ -449,7 +454,7 @@
          {
              flag = true;
          }
-@@ -1199,18 +1429,19 @@
+@@ -1199,18 +1434,19 @@
          }
          else
          {
@@ -475,7 +480,7 @@
              return true;
          }
      }
-@@ -1219,18 +1450,22 @@
+@@ -1219,18 +1455,22 @@
      {
          for (int i = 0; i < this.eventListeners.size(); ++i)
          {
@@ -500,7 +505,7 @@
      }
  
      public void removeEntity(Entity entityIn)
-@@ -1256,12 +1491,12 @@
+@@ -1256,12 +1496,12 @@
      }
  
      public void removeEntityDangerously(Entity entityIn)
@@ -515,7 +520,7 @@
              this.playerEntities.remove(entityIn);
              this.updateAllPlayersSleepingFlag();
          }
-@@ -1273,8 +1508,15 @@
+@@ -1273,8 +1513,15 @@
          {
              this.getChunkFromChunkCoords(i, j).removeEntity(entityIn);
          }
@@ -533,7 +538,7 @@
          this.onEntityRemoved(entityIn);
      }
  
-@@ -1361,6 +1603,11 @@
+@@ -1361,6 +1608,11 @@
  
      public List<AxisAlignedBB> getCollisionBoxes(@Nullable Entity entityIn, AxisAlignedBB aabb)
      {
@@ -545,7 +550,7 @@
          List<AxisAlignedBB> list = Lists.<AxisAlignedBB>newArrayList();
          this.getCollisionBoxes(entityIn, aabb, false, list);
  
-@@ -1391,6 +1638,8 @@
+@@ -1391,6 +1643,8 @@
              }
          }
          net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.GetCollisionBoxesEvent(this, entityIn, aabb, list));
@@ -554,7 +559,7 @@
          return list;
      }
  
-@@ -1677,7 +1926,11 @@
+@@ -1677,7 +1931,11 @@
          for (int i = 0; i < this.weatherEffects.size(); ++i)
          {
              Entity entity = this.weatherEffects.get(i);
@@ -567,7 +572,7 @@
              try
              {
                  if(entity.updateBlocked) continue;
-@@ -1737,6 +1990,8 @@
+@@ -1737,6 +1995,8 @@
          this.tickPlayers();
          this.profiler.endStartSection("regular");
  
@@ -576,7 +581,7 @@
          for (int i1 = 0; i1 < this.loadedEntityList.size(); ++i1)
          {
              Entity entity2 = this.loadedEntityList.get(i1);
-@@ -1758,9 +2013,11 @@
+@@ -1758,9 +2018,11 @@
              {
                  try
                  {
@@ -588,7 +593,7 @@
                  }
                  catch (Throwable throwable1)
                  {
-@@ -1797,7 +2054,9 @@
+@@ -1797,7 +2059,9 @@
              this.profiler.endSection();
          }
  
@@ -598,7 +603,7 @@
  
          this.processingLoadedTiles = true; //FML Move above remove to prevent CMEs
  
-@@ -1821,7 +2080,12 @@
+@@ -1821,7 +2085,12 @@
          while (iterator.hasNext())
          {
              TileEntity tileentity = iterator.next();
@@ -612,15 +617,22 @@
              if (!tileentity.isInvalid() && tileentity.hasWorld())
              {
                  BlockPos blockpos = tileentity.getPos();
-@@ -1834,6 +2098,7 @@
+@@ -1834,8 +2103,13 @@
                          {
                              return String.valueOf((Object)TileEntity.getKey(tileentity.getClass()));
                          });
 +                        tileentity.tickTimer.startTiming(); // Spigot
                          net.minecraftforge.server.timings.TimeTracker.TILE_ENTITY_UPDATE.trackStart(tileentity);
-                         ((ITickable)tileentity).update();
+-                        ((ITickable)tileentity).update();
++
++                        if (red.mohist.util.TileEntity.canTileEntityTick(tileentity, this)) {
++                            ((ITickable)tileentity).update();
++                        }
++
                          net.minecraftforge.server.timings.TimeTracker.TILE_ENTITY_UPDATE.trackEnd(tileentity);
-@@ -1853,6 +2118,12 @@
+                         this.profiler.endSection();
+                     }
+@@ -1853,6 +2127,12 @@
                          else
                          throw new ReportedException(crashreport2);
                      }
@@ -633,7 +645,7 @@
                  }
              }
  
-@@ -1871,6 +2142,8 @@
+@@ -1871,6 +2151,8 @@
              }
          }
  
@@ -642,7 +654,7 @@
          this.processingLoadedTiles = false;
          this.profiler.endStartSection("pendingBlockEntities");
  
-@@ -1882,10 +2155,12 @@
+@@ -1882,10 +2164,12 @@
  
                  if (!tileentity1.isInvalid())
                  {
@@ -655,7 +667,7 @@
  
                      if (this.isBlockLoaded(tileentity1.getPos()))
                      {
-@@ -1893,6 +2168,12 @@
+@@ -1893,6 +2177,12 @@
                          IBlockState iblockstate = chunk.getBlockState(tileentity1.getPos());
                          chunk.addTileEntity(tileentity1.getPos(), tileentity1);
                          this.notifyBlockUpdate(tileentity1.getPos(), iblockstate, iblockstate, 3);
@@ -668,7 +680,7 @@
                      }
                  }
              }
-@@ -1900,6 +2181,7 @@
+@@ -1900,6 +2190,7 @@
              this.addedTileEntityList.clear();
          }
  
@@ -676,7 +688,7 @@
          this.profiler.endSection();
          this.profiler.endSection();
      }
-@@ -1918,7 +2200,7 @@
+@@ -1918,7 +2209,7 @@
          boolean flag = this.loadedTileEntityList.add(tile);
  
          if (flag && tile instanceof ITickable)
@@ -685,7 +697,7 @@
              this.tickableTileEntities.add(tile);
          }
          tile.onLoad();
-@@ -1974,7 +2256,15 @@
+@@ -1974,7 +2265,15 @@
              {
                  return;
              }
@@ -701,7 +713,7 @@
  
          entityIn.lastTickPosX = entityIn.posX;
          entityIn.lastTickPosY = entityIn.posY;
-@@ -1994,6 +2284,7 @@
+@@ -1994,6 +2293,7 @@
              {
                  if(!entityIn.updateBlocked)
                  entityIn.onUpdate();
@@ -709,7 +721,7 @@
              }
          }
  
-@@ -2385,25 +2676,25 @@
+@@ -2385,25 +2685,25 @@
      public TileEntity getTileEntity(BlockPos pos)
      {
          if (this.isOutsideBuildHeight(pos))
@@ -741,7 +753,7 @@
                  tileentity2 = this.getPendingTileEntityAt(pos);
              }
  
-@@ -2431,7 +2722,7 @@
+@@ -2431,7 +2731,7 @@
      {
          pos = pos.toImmutable(); // Forge - prevent mutable BlockPos leaks
          if (!this.isOutsideBuildHeight(pos))
@@ -750,7 +762,7 @@
              if (tileEntityIn != null && !tileEntityIn.isInvalid())
              {
                  if (this.processingLoadedTiles)
-@@ -2454,6 +2745,7 @@
+@@ -2454,6 +2754,7 @@
                      }
  
                      toInvalidate.forEach(TileEntity::invalidate);
@@ -758,7 +770,7 @@
                      this.addedTileEntityList.add(tileEntityIn);
                  }
                  else
-@@ -2505,7 +2797,7 @@
+@@ -2505,7 +2806,7 @@
      public boolean isBlockNormalCube(BlockPos pos, boolean _default)
      {
          if (this.isOutsideBuildHeight(pos))
@@ -767,7 +779,7 @@
              return false;
          }
          else
-@@ -2662,6 +2954,11 @@
+@@ -2662,6 +2963,11 @@
                  }
  
                  this.rainingStrength = MathHelper.clamp(this.rainingStrength, 0.0F, 1.0F);
@@ -779,7 +791,7 @@
              }
          }
      }
-@@ -2851,8 +3148,11 @@
+@@ -2851,8 +3157,11 @@
  
      public boolean checkLightFor(EnumSkyBlock lightType, BlockPos pos)
      {
@@ -792,7 +804,7 @@
              return false;
          }
          else
-@@ -3013,6 +3313,11 @@
+@@ -3013,6 +3322,11 @@
  
      public List<Entity> getEntitiesInAABBexcluding(@Nullable Entity entityIn, AxisAlignedBB boundingBox, @Nullable Predicate <? super Entity > predicate)
      {
@@ -804,7 +816,7 @@
          List<Entity> list = Lists.<Entity>newArrayList();
          int j2 = MathHelper.floor((boundingBox.minX - MAX_ENTITY_RADIUS) / 16.0D);
          int k2 = MathHelper.floor((boundingBox.maxX + MAX_ENTITY_RADIUS) / 16.0D);
-@@ -3029,19 +3334,20 @@
+@@ -3029,19 +3343,20 @@
                  }
              }
          }
@@ -832,7 +844,7 @@
              }
          }
  
-@@ -3070,6 +3376,11 @@
+@@ -3070,6 +3385,11 @@
  
      public <T extends Entity> List<T> getEntitiesWithinAABB(Class <? extends T > clazz, AxisAlignedBB aabb, @Nullable Predicate <? super T > filter)
      {
@@ -844,7 +856,7 @@
          int j2 = MathHelper.floor((aabb.minX - MAX_ENTITY_RADIUS) / 16.0D);
          int k2 = MathHelper.ceil((aabb.maxX + MAX_ENTITY_RADIUS) / 16.0D);
          int l2 = MathHelper.floor((aabb.minZ - MAX_ENTITY_RADIUS) / 16.0D);
-@@ -3086,7 +3397,8 @@
+@@ -3086,7 +3406,8 @@
                  }
              }
          }
@@ -854,7 +866,7 @@
          return list;
      }
  
-@@ -3142,7 +3454,16 @@
+@@ -3142,7 +3463,16 @@
  
          for (Entity entity4 : this.loadedEntityList)
          {
@@ -872,7 +884,7 @@
              {
                  ++j2;
              }
-@@ -3157,6 +3478,9 @@
+@@ -3157,6 +3487,9 @@
          {
              if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityJoinWorldEvent(entity4, this)))
              {
@@ -882,7 +894,7 @@
                  loadedEntityList.add(entity4);
                  this.onEntityAdded(entity4);
              }
-@@ -3173,19 +3497,24 @@
+@@ -3173,19 +3506,24 @@
          IBlockState iblockstate1 = this.getBlockState(pos);
          AxisAlignedBB axisalignedbb = skipCollisionCheck ? null : blockIn.getDefaultState().getCollisionBoundingBox(this, pos);
  
@@ -910,7 +922,7 @@
      }
  
      public int getSeaLevel()
-@@ -3350,6 +3679,11 @@
+@@ -3350,6 +3688,11 @@
          {
              EntityPlayer entityplayer1 = this.playerEntities.get(j2);
  
@@ -922,7 +934,7 @@
              if (p_190525_9_.apply(entityplayer1))
              {
                  double d1 = entityplayer1.getDistanceSq(x, y, z);
-@@ -3367,7 +3701,7 @@
+@@ -3367,7 +3710,7 @@
  
      public boolean isAnyPlayerWithinRangeAt(double x, double y, double z, double range)
      {
@@ -931,7 +943,7 @@
          {
              EntityPlayer entityplayer = this.playerEntities.get(j2);
  
-@@ -3382,8 +3716,8 @@
+@@ -3382,8 +3725,8 @@
              }
          }
  
@@ -942,7 +954,7 @@
  
      @Nullable
      public EntityPlayer getNearestAttackablePlayer(Entity entityIn, double maxXZDistance, double maxYDistance)
-@@ -3406,7 +3740,6 @@
+@@ -3406,7 +3749,6 @@
          for (int j2 = 0; j2 < this.playerEntities.size(); ++j2)
          {
              EntityPlayer entityplayer1 = this.playerEntities.get(j2);
@@ -950,7 +962,7 @@
              if (!entityplayer1.capabilities.disableDamage && entityplayer1.isEntityAlive() && !entityplayer1.isSpectator() && (p_184150_12_ == null || p_184150_12_.apply(entityplayer1)))
              {
                  double d1 = entityplayer1.getDistanceSq(posX, entityplayer1.posY, posZ);
-@@ -3597,6 +3930,16 @@
+@@ -3597,6 +3939,16 @@
      {
      }
  
@@ -967,7 +979,7 @@
      public float getThunderStrength(float delta)
      {
          return (this.prevThunderingStrength + (this.thunderingStrength - this.prevThunderingStrength) * delta) * this.getRainStrength(delta);
-@@ -3885,7 +4228,7 @@
+@@ -3885,7 +4237,7 @@
          int j2 = x * 16 + 8 - blockpos1.getX();
          int k2 = z * 16 + 8 - blockpos1.getZ();
          int l2 = 128;
@@ -976,7 +988,7 @@
      }
  
      /* ======================================== FORGE START =====================================*/
-@@ -3933,6 +4276,10 @@
+@@ -3933,6 +4285,10 @@
  
      public Iterator<Chunk> getPersistentChunkIterable(Iterator<Chunk> chunkIterator)
      {
@@ -987,7 +999,7 @@
          return net.minecraftforge.common.ForgeChunkManager.getPersistentChunksIterableFor(this, chunkIterator);
      }
      /**
-@@ -4021,4 +4368,11 @@
+@@ -4021,4 +4377,11 @@
      {
          return null;
      }

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -63,6 +63,8 @@ import org.bukkit.material.Wood;
 import org.bukkit.material.WoodenStep;
 import org.bukkit.material.Wool;
 
+import javax.annotation.Nullable;
+
 /**
  * An enum of all material IDs accepted by the official server and client
  */
@@ -536,6 +538,7 @@ public enum Material {
     RECORD_12(2267, 1),;
 
     private static Material[] byId = new Material[32676];
+    private static Material[] blockById = new Material[32676];
     private static Map<String, Material> BY_NAME = Maps.newHashMap(); // Cauldron - remove final
 
     static {
@@ -674,28 +677,32 @@ public enum Material {
         return name.toUpperCase(java.util.Locale.ENGLISH).replaceAll("(:|\\s)", "_").replaceAll("\\W", "");
     }
 
-    public static Material addMaterial(int id, int limit, String name) {
-        if (byId[id] == null) {
-            String materialName = normalizeName(name);
-            Material material = EnumHelper.addEnum(Material.class, materialName, new Class[]{Integer.TYPE, Integer.TYPE}, new Object[]{id, limit});
-            byId[id] = material;
-            BY_NAME.put(materialName, material);
-            BY_NAME.put("X" + material.id, material);
+    @Nullable
+    public static Material addMaterial(Material material) {
+        if (byId[material.id] == null) {
+            byId[material.id] = material;
+            BY_NAME.put(normalizeName(material.name()), material);
+            BY_NAME.put("X" + String.valueOf(material.id), material);
             return material;
         }
         return null;
     }
 
-    public static Material addMaterial(int id, String name) {
-        if (byId[id] == null) {
-            String materialName = normalizeName(name);
-            Material material = EnumHelper.addEnum(Material.class, materialName, new Class[]{Integer.TYPE}, new Object[]{id});
-            byId[id] = material;
-            BY_NAME.put(materialName, material);
-            BY_NAME.put("X" + material.id, material);
+    @Nullable
+    public static Material addBlockMaterial(Material material) {
+        if (blockById[material.id] == null) {
+            blockById[material.id] = material;
             return material;
         }
         return null;
+    }
+
+    public static Material getBlockMaterial(final int id) {
+        if (blockById.length > id && id >= 0) {
+            return blockById[id];
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -770,7 +777,7 @@ public enum Material {
      * @return true if this material is a block
      */
     public boolean isBlock() {
-        return id < 256;
+        return Arrays.stream(blockById).anyMatch(material -> this == material);
     }
 
     /**

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftChunkSnapshot.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftChunkSnapshot.java
@@ -53,7 +53,7 @@ public class CraftChunkSnapshot implements ChunkSnapshot {
 
     @Override
     public Material getBlockType(int x, int y, int z) {
-        return Material.getMaterial(getBlockTypeId(x, y, z));
+        return Material.getBlockMaterial(getBlockTypeId(x, y, z));
     }
 
     public final int getBlockTypeId(int x, int y, int z) {

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftStatistic.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftStatistic.java
@@ -123,7 +123,7 @@ public class CraftStatistic {
         }
         Block block = Block.REGISTRY.getObject(new ResourceLocation(val));
         if (block != null) {
-            return Material.getMaterial(Block.getIdFromBlock(block));
+            return Material.getBlockMaterial(Block.getIdFromBlock(block));
         }
         try {
             return Material.getMaterial(Integer.parseInt(val));

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftWorld.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftWorld.java
@@ -1197,7 +1197,7 @@ public class CraftWorld implements World {
     }
 
     public FallingBlock spawnFallingBlock(Location location, int blockId, byte blockData) throws IllegalArgumentException {
-        return spawnFallingBlock(location, org.bukkit.Material.getMaterial(blockId), blockData);
+        return spawnFallingBlock(location, org.bukkit.Material.getBlockMaterial(blockId), blockData);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/block/CraftBlock.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/block/CraftBlock.java
@@ -225,7 +225,7 @@ public class CraftBlock implements Block {
     }
 
     public Material getType() {
-        return Material.getMaterial(getTypeId());
+        return Material.getBlockMaterial(getTypeId());
     }
 
     public void setType(final Material type) {

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/block/CraftBlockState.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/block/CraftBlockState.java
@@ -143,7 +143,7 @@ public class CraftBlockState implements BlockState {
     }
 
     public Material getType() {
-        return Material.getMaterial(getTypeId());
+        return Material.getBlockMaterial(getTypeId());
     }
 
     public void setFlag(int flag) {

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftFallingBlock.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftFallingBlock.java
@@ -28,7 +28,7 @@ public class CraftFallingBlock extends CraftEntity implements FallingBlock {
     }
 
     public Material getMaterial() {
-        return Material.getMaterial(getBlockId());
+        return Material.getBlockMaterial(getBlockId());
     }
 
     public int getBlockId() {

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/generator/CraftChunkData.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/generator/CraftChunkData.java
@@ -57,7 +57,7 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
 
     @Override
     public Material getType(int x, int y, int z) {
-        return Material.getMaterial(getTypeId(x, y, z));
+        return Material.getBlockMaterial(getTypeId(x, y, z));
     }
 
     @Override

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/util/CraftMagicNumbers.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/util/CraftMagicNumbers.java
@@ -46,7 +46,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
     }
 
     public static Block getBlock(int id) {
-        return getBlock(Material.getMaterial(id));
+        return getBlock(Material.getBlockMaterial(id));
     }
 
     public static int getId(Block block) {
@@ -54,7 +54,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
     }
 
     public static Material getMaterial(Block block) {
-        return Material.getMaterial(Block.getIdFromBlock(block));
+        return Material.getBlockMaterial(Block.getIdFromBlock(block));
     }
 
     public static Item getItem(Material material) {

--- a/src/main/java/org/bukkit/event/block/BlockCanBuildEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockCanBuildEvent.java
@@ -70,7 +70,7 @@ public class BlockCanBuildEvent extends BlockEvent {
      * @return The Material that we are trying to place
      */
     public Material getMaterial() {
-        return Material.getMaterial(material);
+        return Material.getBlockMaterial(material);
     }
 
     /**

--- a/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java
@@ -44,7 +44,7 @@ public class BlockPhysicsEvent extends BlockEvent implements Cancellable {
      * @return Changed block's type
      */
     public Material getChangedType() {
-        return Material.getMaterial(changed);
+        return Material.getBlockMaterial(changed);
     }
 
     public boolean isCancelled() {

--- a/src/main/java/red/mohist/command/TileEntityCommand.java
+++ b/src/main/java/red/mohist/command/TileEntityCommand.java
@@ -1,0 +1,87 @@
+package red.mohist.command;
+
+import java.util.*;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import red.mohist.configuration.TileEntityConfig;
+import red.mohist.util.i18n.Message;
+
+public class TileEntityCommand extends Command {
+
+    public TileEntityCommand(String name) {
+        super(name);
+        System.out.println("testt ttetwet");
+        this.description = "TileEntity tick limiting commands";
+        this.usageMessage = "/tileentity [reload|dump-all|dump-existing]";
+        this.setPermission("mohist.command.mohist");
+    }
+
+    private List<String> params = Arrays.asList("reload", "dump-all", "dump-existing");
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        List<String> list = new ArrayList<>();
+        if (args.length == 1 && (sender.isOp() || testPermission(sender))) {
+            for (String param : params) {
+                if (param.toLowerCase().startsWith(args[0].toLowerCase())) {
+                    list.add(param);
+                }
+            }
+        }
+
+        return list;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String commandLabel, String[] args) {
+        if (!sender.isOp() || !testPermission(sender)) {
+            sender.sendMessage(Message.getString("command.nopermission"));
+            return true;
+        }
+
+        if (args.length == 0) {
+            sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+            return false;
+        }
+
+        switch (args[0].toLowerCase(Locale.ENGLISH)) {
+            case "reload":
+                MinecraftServer.tileEntityConfig.load();
+                sender.sendMessage(ChatColor.GREEN + "tileentity.yml reload complete.");
+                break;
+
+            case "dump-existing":
+                MinecraftServer.tileEntityConfig.save();
+                sender.sendMessage(ChatColor.GREEN + "tileentity.yml updated with found TileEntities");
+                break;
+
+            case "dump-names":
+                Iterator i = TileEntity.getRegisteredTileEntities().iterator();
+
+                for (Object rl : TileEntity.getRegisteredTileEntities().getKeys()) {
+                    ResourceLocation a = (ResourceLocation) rl;
+
+                    MinecraftServer.LOGGER.info(
+                            "Found TileEntity with name: " + red.mohist.util.TileEntity.sanitizeClassName(
+                                    ((Class)TileEntity.getRegisteredTileEntities().getObject(rl))
+                            )
+                    );
+                }
+
+                sender.sendMessage(ChatColor.GREEN + "tileentity.yml updated with new TileEntity definitions.");
+                break;
+
+            default:
+                sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/red/mohist/common/cache/TileEntityCache.java
+++ b/src/main/java/red/mohist/common/cache/TileEntityCache.java
@@ -1,0 +1,21 @@
+package red.mohist.common.cache;
+
+import net.minecraft.tileentity.TileEntity;
+
+public class TileEntityCache {
+
+    public Class<? extends TileEntity> tileEntityClass;
+    public boolean tickNoPlayers = false;
+    public int tickInterval = 1;
+    public String configPath;
+    public String worldName;
+
+    public TileEntityCache(Class<? extends TileEntity> tileEntityClass, String worldName, String configPath, boolean tickNoPlayers, int tickInterval)
+    {
+        this.tileEntityClass = tileEntityClass;
+        this.worldName = worldName;
+        this.tickNoPlayers = tickNoPlayers;
+        this.tickInterval = tickInterval;
+        this.configPath = configPath;
+    }
+}

--- a/src/main/java/red/mohist/configuration/TileEntityConfig.java
+++ b/src/main/java/red/mohist/configuration/TileEntityConfig.java
@@ -1,0 +1,88 @@
+package red.mohist.configuration;
+
+import net.minecraft.server.MinecraftServer;
+import org.bukkit.configuration.file.YamlConfiguration;
+import red.mohist.command.TileEntityCommand;
+import red.mohist.common.cache.TileEntityCache;
+import red.mohist.util.TileEntity;
+
+public class TileEntityConfig extends ConfigBase
+{
+    private final String HEADER = "This is the main configuration file for TileEntities.\n"
+            + "\n"
+            + "If you need help with the configuration or have any questions related to Cauldron,\n"
+            + "join us at the IRC or drop by our forums and leave a post.\n"
+            + "\n"
+            + "IRC: #cauldron @ irc.esper.net ( http://webchat.esper.net/?channel=cauldron )\n"
+            + "Forums: http://cauldron.minecraftforge.net/\n";
+
+    public static TileEntityConfig instance;
+//    protected Map<String, Boolean> tickNoPlayers = new HashMap<String, Boolean>();
+//    protected Map<String, Integer> tickInterval = new HashMap<String, Integer>();
+
+
+    /* ======================================================================== */
+    public final BoolSetting skipTileEntityTicks = new BoolSetting(this, "settings.skip-tileentity-ticks", true, "If enabled, turns on tileentity tick skip feature when no players are near.");
+    public final BoolSetting enableTECanUpdateWarning = new BoolSetting(this, "debug.enable-te-can-update-warning", false, "Set true to detect which tileentities should not be ticking. (not implemented)");
+    public final BoolSetting enableTEInventoryWarning = new BoolSetting(this, "debug.enable-te-inventory-warning", false, "Set true to detect which tileentities with inventory failed to detect size for Bukkit's InventoryType enum. Note: This may detect a false-positive. (not implemented)");
+    public final BoolSetting enableTEPlaceWarning = new BoolSetting(this, "debug.enable-te-place-warning", false, "Warn when a mod requests tile entity from a block that doesn't support one (not implemented)");
+    public final BoolSetting preventInvalidTileEntityUpdates = new BoolSetting(this, "settings.prevent-invalid-tileentity-updates", true, "Used to determine if a tileentity should tick and if not the TE is added to a ban list. Note: This should help improve performance. (not implemented)");
+    /* ======================================================================== */
+
+    public TileEntityConfig()
+    {
+        super("tileentity.yml", "tileentity");
+        init();
+        instance = this;
+    }
+
+    @Override
+    public void addCommands()
+    {
+        commands.put("tileentity", new TileEntityCommand("tileentity"));
+    }
+
+    public void init()
+    {
+        settings.put(skipTileEntityTicks.path, skipTileEntityTicks);
+        settings.put(enableTECanUpdateWarning.path, enableTECanUpdateWarning);
+        settings.put(enableTEInventoryWarning.path, enableTEInventoryWarning);
+        settings.put(enableTEPlaceWarning.path, enableTEPlaceWarning);
+        settings.put(preventInvalidTileEntityUpdates.path, preventInvalidTileEntityUpdates);
+        load();
+    }
+
+    public void load()
+    {
+        try
+        {
+            config = YamlConfiguration.loadConfiguration(configFile);
+            String header = HEADER + "\n";
+            for (Setting toggle : settings.values())
+            {
+                if (!toggle.description.equals(""))
+                    header += "Setting: " + toggle.path + " Default: " + toggle.def + "   # " + toggle.description + "\n";
+
+                config.addDefault(toggle.path, toggle.def);
+                settings.get(toggle.path).setValue(config.getString(toggle.path));
+            }
+            config.options().header(header);
+            config.options().copyDefaults(true);
+
+            version = getInt("config-version", 1);
+            set("config-version", 1);
+
+            for (TileEntityCache teCache : TileEntity.tileEntityCache.values())
+            {
+                teCache.tickNoPlayers = config.getBoolean( "world-settings." + teCache.worldName + "." + teCache.configPath + ".tick-no-players", config.getBoolean( "world-settings.default." + teCache.configPath + ".tick-no-players") );
+                teCache.tickInterval = config.getInt( "world-settings." + teCache.worldName + "." + teCache.configPath + ".tick-interval", config.getInt( "world-settings.default." + teCache.configPath + ".tick-interval") );
+            }
+            this.save();
+        }
+        catch (Exception ex)
+        {
+            MinecraftServer.LOGGER.warn("Could not load " + this.configFile);
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/red/mohist/configuration/TileEntityWorldConfig.java
+++ b/src/main/java/red/mohist/configuration/TileEntityWorldConfig.java
@@ -1,0 +1,8 @@
+package red.mohist.configuration;
+
+public class TileEntityWorldConfig extends WorldConfig {
+    public TileEntityWorldConfig(String worldName, ConfigBase configFile)
+    {
+        super(worldName, configFile);
+    }
+}

--- a/src/main/java/red/mohist/forge/ForgeInjectBukkit.java
+++ b/src/main/java/red/mohist/forge/ForgeInjectBukkit.java
@@ -45,7 +45,8 @@ public class ForgeInjectBukkit {
             if(!entry.getKey().getResourceDomain().equals("minecraft")) {
                 String materialName = Material.normalizeName(entry.getKey().toString());
                 // inject item materials into Bukkit for FML
-                Material material = Material.addMaterial(Item.getIdFromItem(entry.getValue()), entry.getValue().getItemStackLimit(), materialName);
+                Item item = entry.getValue();
+                Material material = Material.addMaterial(EnumHelper.addEnum(Material.class, materialName, new Class[]{Integer.TYPE, Integer.TYPE}, new Object[]{Item.getIdFromItem(item), item.getItemStackLimit()}));
                 if (material != null) {
                     ServerAPI.injectmaterials.put(material.name(), material.getId());
                     Mohist.LOGGER.debug("Save: " + Message.getFormatString("injected.item", new Object[]{material.name(), String.valueOf(material.getId()), String.valueOf(ItemAPI.getBukkit(material).getDurability())}));
@@ -59,11 +60,18 @@ public class ForgeInjectBukkit {
             if(!entry.getKey().getResourceDomain().equals("minecraft")) {
                 String materialName = Material.normalizeName(entry.getKey().toString());
                 // inject block materials into Bukkit for FML
-                Material material = Material.addMaterial(Block.getIdFromBlock(entry.getValue()), materialName);
+                Block block = entry.getValue();
+                Material material = Material.addBlockMaterial(EnumHelper.addEnum(Material.class, materialName, new Class[]{Integer.TYPE}, new Object[]{Block.getIdFromBlock(block)}));
                 if (material != null) {
                     ServerAPI.injectblock.put(material.name(), material.getId());
                     Mohist.LOGGER.debug("Save: " + Message.getFormatString("injected.block", new Object[]{material.name(), String.valueOf(material.getId())}));
                 }
+            }
+        }
+
+        for (Material material : Material.values()) {
+            if (material.getId() < 256) {
+                Material.addBlockMaterial(material);
             }
         }
     }

--- a/src/main/java/red/mohist/util/TileEntity.java
+++ b/src/main/java/red/mohist/util/TileEntity.java
@@ -1,0 +1,66 @@
+package red.mohist.util;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+import org.spigotmc.ActivationRange;
+import red.mohist.common.cache.TileEntityCache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TileEntity {
+    public static Map<Class<? extends net.minecraft.tileentity.TileEntity>, TileEntityCache> tileEntityCache = new HashMap<Class<? extends net.minecraft.tileentity.TileEntity>, TileEntityCache>();
+
+    public static String sanitizeClassName(Class clazz)
+    {
+        String name = clazz.getName().replace(".", "-");
+
+        return name.replaceAll("[^A-Za-z0-9\\-]", "");
+    }
+
+    public static String sanitizeClassName(net.minecraft.tileentity.TileEntity tileEntity)
+    {
+        return sanitizeClassName(tileEntity.getClass());
+    }
+
+    public static boolean canTileEntityTick(net.minecraft.tileentity.TileEntity tileEntity, World world)
+    {
+        if (tileEntity == null) {
+            return false;
+        }
+
+        if (world.tileentityConfig == null) {
+            return true;
+        }
+
+        if (MinecraftServer.tileEntityConfig.skipTileEntityTicks.getValue())
+        {
+            TileEntityCache teCache = tileEntityCache.get(tileEntity.getClass());
+            if (teCache == null)
+            {
+                String teConfigPath = sanitizeClassName(tileEntity);
+                teCache = new TileEntityCache(tileEntity.getClass(), world.getWorldInfo().getWorldName().toLowerCase(), teConfigPath, world.tileentityConfig.getBoolean(teConfigPath + ".tick-no-players", false), world.tileentityConfig.getInt(teConfigPath + ".tick-interval", 1));
+                tileEntityCache.put(tileEntity.getClass(), teCache);
+            }
+
+
+            // do not tick if no players in range
+            // @TODO not implemented yet
+//            if (!teCache.tickNoPlayers && !ActivationRange.checkIfActive(tileEntity))
+//            {
+//
+//                return false;
+//            }
+
+            // Skip tick interval
+            if (teCache.tickInterval > 0 && (world.getWorldInfo().getWorldTotalTime() % teCache.tickInterval == 0L))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Fixed problem with giving modded blocks in some plugins (for example great kits), some code from magma.
Added feature to make tileentity tick-interval, tick-no-players not implemented yet.

Added /tileentity command: 
/tileentity dump-existing - will dump loaded tileentity definition to config
/tileentity dump-all - will dump all registered tileentity definition to console
/tileentity reload - reload tick-intervals