### PR TITLE
Add skipActivationRange entity setting

### DIFF
--- a/src/main/java/org/spigotmc/ActivationRange.java
+++ b/src/main/java/org/spigotmc/ActivationRange.java
@@ -218,6 +218,10 @@ public class ActivationRange {
      * @return
      */
     public static boolean checkIfActive(Entity entity) {
+        if (MinecraftServer.entityConfig != null
+            && MinecraftServer.entityConfig.skipActivationRange.getValue())
+            return true;
+
         SpigotTimings.checkIfActiveTimer.startTiming();
         // Never safe to skip fireworks or entities not yet added to chunk
         // PAIL: inChunk

--- a/src/main/java/red/mohist/configuration/EntityConfig.java
+++ b/src/main/java/red/mohist/configuration/EntityConfig.java
@@ -12,6 +12,7 @@ public class EntityConfig extends ConfigBase
 
     public static EntityConfig instance;
     public final BoolSetting skipEntityTicks = new BoolSetting(this, "settings.skip-entity-ticks", true, "If enabled, turns on entity tick skip feature.");
+    public final BoolSetting skipActivationRange = new BoolSetting(this, "settings.skip-activation-range", false, "If enabled, skips entity activation range checks.");
 
     public EntityConfig()
     {
@@ -23,6 +24,7 @@ public class EntityConfig extends ConfigBase
     public void init()
     {
         settings.put(skipEntityTicks.path, skipEntityTicks);
+        settings.put(skipActivationRange.path, skipActivationRange);
         load();
     }
 


### PR DESCRIPTION
This allows disabling Spigot's activation range checks and allows entities to tick when found in heights less than 0 or higher than 255, this is required for CubicChunks to work properly.

While investigating these entity issues, [@z3nth10n](https://github.com/z3nth10n) pointed me to this line in the World class patch and after some tests it was clear that Spigot's activation range checks were the culprit.

https://github.com/Mohist-Community/Mohist/blob/5defd8c41b7cc135bd26549d42c660a3616ad0d5/patches/net/minecraft/world/World.java.patch#L1231

There may be a better way to fix these checks to support CubicChunks while balancing performance but for now I believe it's an acceptable compromise.