### PR TITLE
Update log4j2_mohist.xml

### DIFF
--- a/src/main/resources/log4j2_mohist.xml
+++ b/src/main/resources/log4j2_mohist.xml
@@ -18,6 +18,8 @@
         <!-- make sure mojang's logging is set to 'info' so that their LOGGER.isDebugEnabled() behavior isn't active -->
         <Logger level="info" name="com.mojang"/>
         <Logger level="info" name="net.minecraft"/>
+        <Logger level="error" name="org.apache"/>
+        <Logger level="error" name="httpclient"/>
         <Root level="all">
             <filters>
                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL"/>


### PR DESCRIPTION
Mods using Apache http very much flood the console with Apache logs. This will only display error information.