### PR TITLE
Fixes #759

### DIFF
--- a/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
@@ -180,7 +180,7 @@
        }
 -
 +      // CraftBukkit start - add fields and methods
-+      this.craftServer = p_i1530_1_.server;
++      this.craftServer = p_i1530_1_ != null ? p_i1530_1_.server : null;
     }
  
     public void func_73660_a() {


### PR DESCRIPTION
Some mods (e.g. Placebo) create fake ServerPlayNetHandler with MinecraftServer arg supplied as 'null'.
This PR prevents possible NullPointerException (and server crash) in constructor.