### PR TITLE
Fixes #769

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -147,7 +147,7 @@
        this.field_241107_Q_ = p_i241885_13_;
        this.field_73061_a = p_i241885_1_;
        this.field_241104_N_ = p_i241885_12_;
-@@ -200,9 +215,39 @@
+@@ -200,9 +215,31 @@
        } else {
           this.field_241105_O_ = null;
        }
@@ -171,23 +171,15 @@
     }
  
 +   private TileEntity fixTileEntity(BlockPos pos, Block type, TileEntity found) {
-+      this.getCBServer().getLogger().log(
-+          Level.SEVERE, "Block at {0}, {1}, {2} is {3} but has {4}. Bukkit will attempt to fix this, but there may be additional damage that we cannot recover.", new Object[] { pos.func_177958_n(), pos.func_177956_o(), pos.func_177952_p(), type, found });
-+      if (type instanceof ITileEntityProvider) {
-+         TileEntity replacement = ((ITileEntityProvider)type).func_196283_a_(this);
-+         replacement.field_145850_b = this;
-+         this.func_175690_a(pos, replacement);
-+         return replacement;
-+      } else {
-+         return found;
-+      }
++      // Disable tile entity fix
++      return found;
 +   }
 +   // CraftBukkit end
 +
     public void func_241113_a_(int p_241113_1_, int p_241113_2_, boolean p_241113_3_, boolean p_241113_4_) {
        this.field_241103_E_.func_230391_a_(p_241113_1_);
        this.field_241103_E_.func_76080_g(p_241113_2_);
-@@ -211,6 +256,7 @@
+@@ -211,6 +248,7 @@
        this.field_241103_E_.func_76069_a(p_241113_4_);
     }
  
@@ -195,7 +187,7 @@
     public Biome func_225604_a_(int p_225604_1_, int p_225604_2_, int p_225604_3_) {
        return this.func_72863_F().func_201711_g().func_202090_b().func_225526_b_(p_225604_1_, p_225604_2_, p_225604_3_);
     }
-@@ -296,27 +342,39 @@
+@@ -296,27 +334,39 @@
           this.field_73061_a.func_184103_al().func_232642_a_(new SChangeGameStatePacket(SChangeGameStatePacket.field_241772_i_, this.field_73017_q), this.func_234923_W_());
        }
  
@@ -244,7 +236,7 @@
           if (this.func_82736_K().func_223586_b(GameRules.field_223617_t)) {
              this.func_73051_P();
           }
-@@ -327,15 +385,19 @@
+@@ -327,15 +377,19 @@
        iprofiler.func_219895_b("chunkSource");
        this.func_72863_F().func_217207_a(p_72835_1_);
        iprofiler.func_219895_b("tickPending");
@@ -264,7 +256,7 @@
        this.field_211159_Q = false;
        iprofiler.func_219895_b("entities");
        boolean flag3 = !this.field_217491_A.isEmpty() || !this.func_217469_z().isEmpty();
-@@ -344,6 +406,7 @@
+@@ -344,6 +398,7 @@
        }
  
        if (flag3 || this.field_80004_Q++ < 300) {
@@ -272,7 +264,7 @@
           if (this.field_241105_O_ != null) {
              this.field_241105_O_.func_186105_b();
           }
-@@ -351,18 +414,22 @@
+@@ -351,18 +406,22 @@
           this.field_217492_a = true;
           ObjectIterator<Entry<Entity>> objectiterator = this.field_217498_x.int2ObjectEntrySet().iterator();
  
@@ -295,7 +287,7 @@
                    this.func_217391_K();
                    break label164;
                 }
-@@ -404,7 +471,7 @@
+@@ -404,7 +463,7 @@
              if (entity1.field_70128_L) {
                 this.func_217454_n(entity1);
                 objectiterator.remove();
@@ -304,7 +296,7 @@
              }
  
              iprofiler.func_76319_b();
-@@ -460,13 +527,13 @@
+@@ -460,13 +519,13 @@
                 skeletonhorseentity.func_190691_p(true);
                 skeletonhorseentity.func_70873_a(0);
                 skeletonhorseentity.func_70107_b((double)blockpos.func_177958_n(), (double)blockpos.func_177956_o(), (double)blockpos.func_177952_p());
@@ -320,7 +312,7 @@
           }
        }
  
-@@ -475,12 +542,13 @@
+@@ -475,12 +534,13 @@
           BlockPos blockpos2 = this.func_205770_a(Heightmap.Type.MOTION_BLOCKING, this.func_217383_a(i, 0, j, 15));
           BlockPos blockpos3 = blockpos2.func_177977_b();
           Biome biome = this.func_226691_t_(blockpos2);
@@ -336,7 +328,7 @@
           }
  
           if (flag && this.func_226691_t_(blockpos3).func_201851_b() == Biome.RainType.RAIN) {
-@@ -544,7 +612,7 @@
+@@ -544,7 +604,7 @@
           int j = 0;
  
           for(ServerPlayerEntity serverplayerentity : this.field_217491_A) {
@@ -345,7 +337,7 @@
                 ++i;
              } else if (serverplayerentity.func_70608_bn()) {
                 ++j;
-@@ -561,10 +629,22 @@
+@@ -561,10 +621,22 @@
     }
  
     private void func_73051_P() {
@@ -370,7 +362,7 @@
     }
  
     public void func_82742_i() {
-@@ -591,6 +671,14 @@
+@@ -591,6 +663,14 @@
        if (!(p_217479_1_ instanceof PlayerEntity) && !this.func_72863_F().func_217204_a(p_217479_1_)) {
           this.func_217464_b(p_217479_1_);
        } else {
@@ -385,7 +377,7 @@
           p_217479_1_.func_226286_f_(p_217479_1_.func_226277_ct_(), p_217479_1_.func_226278_cu_(), p_217479_1_.func_226281_cx_());
           p_217479_1_.field_70126_B = p_217479_1_.field_70177_z;
           p_217479_1_.field_70127_C = p_217479_1_.field_70125_A;
-@@ -598,10 +686,12 @@
+@@ -598,10 +678,12 @@
              ++p_217479_1_.field_70173_aa;
              IProfiler iprofiler = this.func_217381_Z();
              iprofiler.func_194340_a(() -> {
@@ -399,7 +391,7 @@
              iprofiler.func_76319_b();
           }
  
-@@ -611,6 +701,7 @@
+@@ -611,6 +693,7 @@
                 this.func_217459_a(p_217479_1_, entity);
              }
           }
@@ -407,7 +399,7 @@
  
        }
     }
-@@ -629,6 +720,7 @@
+@@ -629,6 +712,7 @@
                 });
                 iprofiler.func_230035_c_("tickPassenger");
                 p_217459_2_.func_70098_U();
@@ -415,7 +407,7 @@
                 iprofiler.func_76319_b();
              }
  
-@@ -649,7 +741,7 @@
+@@ -649,7 +733,7 @@
        if (p_217464_1_.func_233578_ci_()) {
           this.func_217381_Z().func_76320_a("chunkCheck");
           int i = MathHelper.func_76128_c(p_217464_1_.func_226277_ct_() / 16.0D);
@@ -424,7 +416,7 @@
           int k = MathHelper.func_76128_c(p_217464_1_.func_226281_cx_() / 16.0D);
           if (!p_217464_1_.field_70175_ag || p_217464_1_.field_70176_ah != i || p_217464_1_.field_70162_ai != j || p_217464_1_.field_70164_aj != k) {
              if (p_217464_1_.field_70175_ag && this.func_217354_b(p_217464_1_.field_70176_ah, p_217464_1_.field_70164_aj)) {
-@@ -658,7 +750,7 @@
+@@ -658,7 +742,7 @@
  
              if (!p_217464_1_.func_233577_ch_() && !this.func_217354_b(i, k)) {
                 if (p_217464_1_.field_70175_ag) {
@@ -433,7 +425,7 @@
                 }
  
                 p_217464_1_.field_70175_ag = false;
-@@ -678,6 +770,7 @@
+@@ -678,6 +762,7 @@
     public void func_217445_a(@Nullable IProgressUpdate p_217445_1_, boolean p_217445_2_, boolean p_217445_3_) {
        ServerChunkProvider serverchunkprovider = this.func_72863_F();
        if (!p_217445_3_) {
@@ -441,7 +433,7 @@
           if (p_217445_1_ != null) {
              p_217445_1_.func_200210_a(new TranslationTextComponent("menu.savingLevel"));
           }
-@@ -687,6 +780,7 @@
+@@ -687,6 +772,7 @@
              p_217445_1_.func_200209_c(new TranslationTextComponent("menu.savingChunks"));
           }
  
@@ -449,7 +441,7 @@
           serverchunkprovider.func_217210_a(p_217445_2_);
        }
     }
-@@ -743,13 +837,23 @@
+@@ -743,13 +829,23 @@
     }
  
     public boolean func_217376_c(Entity p_217376_1_) {
@@ -475,7 +467,7 @@
     public void func_217460_e(Entity p_217460_1_) {
        boolean flag = p_217460_1_.field_98038_p;
        p_217460_1_.field_98038_p = true;
-@@ -777,9 +881,10 @@
+@@ -777,9 +873,10 @@
     }
  
     private void func_217448_f(ServerPlayerEntity p_217448_1_) {
@@ -487,7 +479,7 @@
           entity.func_213319_R();
           this.func_217434_e((ServerPlayerEntity)entity);
        }
-@@ -795,18 +900,24 @@
+@@ -795,18 +892,24 @@
     }
  
     private boolean func_72838_d(Entity p_72838_1_) {
@@ -518,7 +510,7 @@
              return true;
           }
        }
-@@ -816,6 +927,7 @@
+@@ -816,6 +919,7 @@
        if (this.func_217478_l(p_217440_1_)) {
           return false;
        } else {
@@ -526,7 +518,7 @@
           this.func_217465_m(p_217440_1_);
           return true;
        }
-@@ -827,7 +939,7 @@
+@@ -827,7 +931,7 @@
        if (entity == null) {
           return false;
        } else {
@@ -535,7 +527,7 @@
           return true;
        }
     }
-@@ -851,15 +963,30 @@
+@@ -851,15 +955,30 @@
     }
  
     public boolean func_242106_g(Entity p_242106_1_) {
@@ -568,7 +560,7 @@
        this.field_147483_b.addAll(p_217466_1_.func_177434_r().values());
        ClassInheritanceMultiMap<Entity>[] aclassinheritancemultimap = p_217466_1_.func_177429_s();
        int i = aclassinheritancemultimap.length;
-@@ -879,12 +1006,41 @@
+@@ -879,12 +998,41 @@
  
     }
  
@@ -611,7 +603,7 @@
  
        this.field_175741_N.remove(p_217484_1_.func_110124_au());
        this.func_72863_F().func_217226_b(p_217484_1_);
-@@ -894,10 +1050,19 @@
+@@ -894,10 +1042,19 @@
        }
  
        this.func_96441_U().func_181140_a(p_217484_1_);
@@ -631,7 +623,7 @@
     }
  
     private void func_217465_m(Entity p_217465_1_) {
-@@ -913,20 +1078,31 @@
+@@ -913,20 +1070,31 @@
  
           this.field_175741_N.put(p_217465_1_.func_110124_au(), p_217465_1_);
           this.func_72863_F().func_217230_c(p_217465_1_);
@@ -664,7 +656,7 @@
        }
     }
  
-@@ -939,17 +1115,47 @@
+@@ -939,17 +1107,47 @@
     }
  
     public void func_217434_e(ServerPlayerEntity p_217434_1_) {
@@ -714,7 +706,7 @@
              if (d0 * d0 + d1 * d1 + d2 * d2 < 1024.0D) {
                 serverplayerentity.field_71135_a.func_147359_a(new SAnimateBlockBreakPacket(p_175715_1_, p_175715_2_, p_175715_3_));
              }
-@@ -959,10 +1165,20 @@
+@@ -959,10 +1157,20 @@
     }
  
     public void func_184148_a(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {
@@ -735,7 +727,7 @@
        this.field_73061_a.func_184103_al().func_148543_a(p_217384_1_, p_217384_2_.func_226277_ct_(), p_217384_2_.func_226278_cu_(), p_217384_2_.func_226281_cx_(), p_217384_5_ > 1.0F ? (double)(16.0F * p_217384_5_) : 16.0D, this.func_234923_W_(), new SSpawnMovingSoundEffectPacket(p_217384_3_, p_217384_4_, p_217384_2_, p_217384_5_, p_217384_6_));
     }
  
-@@ -997,9 +1213,17 @@
+@@ -997,9 +1205,17 @@
     }
  
     public Explosion func_230546_a_(@Nullable Entity p_230546_1_, @Nullable DamageSource p_230546_2_, @Nullable ExplosionContext p_230546_3_, double p_230546_4_, double p_230546_6_, double p_230546_8_, float p_230546_10_, boolean p_230546_11_, Explosion.Mode p_230546_12_) {
@@ -756,7 +748,7 @@
        if (p_230546_12_ == Explosion.Mode.NONE) {
           explosion.func_180342_d();
        }
-@@ -1054,12 +1278,19 @@
+@@ -1054,12 +1270,19 @@
     }
  
     public <T extends IParticleData> int func_195598_a(T p_195598_1_, double p_195598_2_, double p_195598_4_, double p_195598_6_, int p_195598_8_, double p_195598_9_, double p_195598_11_, double p_195598_13_, double p_195598_15_) {
@@ -778,7 +770,7 @@
              ++i;
           }
        }
-@@ -1131,7 +1362,13 @@
+@@ -1131,7 +1354,13 @@
     @Nullable
     public MapData func_217406_a(String p_217406_1_) {
        return this.func_73046_m().func_241755_D_().func_217481_x().func_215753_b(() -> {
@@ -793,7 +785,7 @@
        }, p_217406_1_);
     }
  
-@@ -1333,6 +1570,11 @@
+@@ -1333,6 +1562,11 @@
  
     public void func_230547_a_(BlockPos p_230547_1_, Block p_230547_2_) {
        if (!this.func_234925_Z_()) {
@@ -805,7 +797,7 @@
           this.func_195593_d(p_230547_1_, p_230547_2_);
        }
  
-@@ -1399,15 +1641,44 @@
+@@ -1399,15 +1633,44 @@
     }
  
     public static void func_241121_a_(ServerWorld p_241121_0_) {


### PR DESCRIPTION
Although this change may seem controversial, I found that tile entity fix functionality provided by CraftBukkit in reality only breaks mod tile entities.
For example, disabling TE fix functionality closes MetalBarrels issue (#769)