### PR TITLE
Dimension TP fix + Stacktrace for task failures

### DIFF
--- a/patches/minecraft/net/minecraft/block/PortalSize.java.patch
+++ b/patches/minecraft/net/minecraft/block/PortalSize.java.patch
@@ -63,13 +63,15 @@
     }
  
     public boolean func_208508_f() {
-@@ -187,19 +211,19 @@
-       return new Vector3d(d2, d4, d3);
+@@ -188,18 +212,22 @@
     }
  
--   public static PortalInfo func_242963_a(ServerWorld p_242963_0_, TeleportationRepositioner.Result p_242963_1_, Direction.Axis p_242963_2_, Vector3d p_242963_3_, EntitySize p_242963_4_, Vector3d p_242963_5_, float p_242963_6_, float p_242963_7_) {
+    public static PortalInfo func_242963_a(ServerWorld p_242963_0_, TeleportationRepositioner.Result p_242963_1_, Direction.Axis p_242963_2_, Vector3d p_242963_3_, EntitySize p_242963_4_, Vector3d p_242963_5_, float p_242963_6_, float p_242963_7_) {
 -      BlockPos blockpos = p_242963_1_.field_243679_a;
 -      BlockState blockstate = p_242963_0_.func_180495_p(blockpos);
++       return func_242963_a(p_242963_0_, p_242963_1_, p_242963_2_, p_242963_3_, p_242963_4_, p_242963_5_, p_242963_6_, p_242963_7_, null); // TODO Mohist
++   }
++
 +   public static PortalInfo func_242963_a(ServerWorld world, TeleportationRepositioner.Result result, Direction.Axis axis, Vector3d offsetVector, EntitySize size, Vector3d motion, float rotationYaw, float rotationPitch, CraftPortalEvent portalEventInfo) {
 +      BlockPos blockpos = result.field_243679_a;
 +      BlockState blockstate = world.func_180495_p(blockpos);

--- a/patches/minecraft/net/minecraft/util/concurrent/ThreadTaskExecutor.java.patch
+++ b/patches/minecraft/net/minecraft/util/concurrent/ThreadTaskExecutor.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/util/concurrent/ThreadTaskExecutor.java
 +++ b/net/minecraft/util/concurrent/ThreadTaskExecutor.java
-@@ -135,7 +135,7 @@
+@@ -135,7 +135,8 @@
        try {
           p_213166_1_.run();
        } catch (Exception exception) {
 -         field_213172_c.fatal("Error executing task on {}", this.func_213142_bd(), exception);
-+         field_213172_c.fatal(com.mohistmc.util.i18n.i18n.get("threadtaskexecutor.1", this.func_213142_bd(), exception));
++         field_213172_c.fatal(com.mohistmc.util.i18n.i18n.get("threadtaskexecutor.1", this.func_213142_bd()));
++         exception.printStackTrace();
        }
  
     }


### PR DESCRIPTION
This PR introduces:
1. Missing method in PortalSize which is referenced by dimension mods such as Gaia Dimension/The Undergarden (closes issue #775)
2. Exception stacktrace is now being printed on task failure: this allows for bugreports/issues to be more full & specific.