### PR TITLE
Fix crash with mod Golem entities

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/entity/CraftEntity.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/entity/CraftEntity.java
@@ -318,6 +318,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
                     if (entity instanceof SnowGolemEntity) { return new CraftSnowman(server, (SnowGolemEntity) entity); }
                     else if (entity instanceof IronGolemEntity) { return new CraftIronGolem(server, (IronGolemEntity) entity); }
                     else if (entity instanceof ShulkerEntity) { return new CraftShulker(server, (ShulkerEntity) entity); }
+                    else { return new CraftGolem(server, (GolemEntity) entity); }
                 }
                 else if (entity instanceof AbstractVillagerEntity) {
                     if (entity instanceof VillagerEntity) { return new CraftVillager(server, (VillagerEntity) entity); }


### PR DESCRIPTION
This PR fixes server crashing because of any mod entity that extends GolemEntity class (crystal golem from Gaia Dimension, for example)