### PR TITLE
Partly fixes #768 (workbench)

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -238,7 +238,7 @@
              }
  
 +            // CraftBukkit start
-+            if (blockSnapshot == null || !this.captureBlockStates) {// Don't notify clients or update physics while capturing blockstates
++            if (blockSnapshot == null && !this.captureBlockStates) {// Don't notify clients or update physics while capturing blockstates
 +               // Modularize client and physic updates
 +               // Spigot start
 +               try {


### PR DESCRIPTION
Because of a flawed "if" statement, markAndNotifyBlock() was always called, resulting in excessive and bugged block update routines.
With this PR applied, placing of engineer's workbench from Immersive Engineering is working as intended.