### PR TITLE
Revert NetworkHooks changes + Craft fix

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/ShapelessRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/ShapelessRecipe.java.patch
@@ -93,7 +93,7 @@
 -      return i == this.field_77579_b.size() && recipeitemhelper.func_194116_a(this, (IntList)null);
 +      //return i == this.recipeItems.size() && (isSimple ? recipeitemhelper.canCraft(this, (IntList)null) : net.minecraftforge.common.util.RecipeMatcher.findMatches(inputs,  this.recipeItems) != null);
 +      // Paper start
-+      if (matchedProvided.isEmpty() || matchedIngredients.isEmpty()) {
++      if (isSimple && (matchedProvided.isEmpty() || matchedIngredients.isEmpty())) {
 +         return false;
 +      }
 +      java.util.List<Ingredient> ingredients = new java.util.ArrayList<>(this.field_77579_b);

--- a/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
@@ -29,10 +29,8 @@ import java.util.stream.Collectors;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
-import net.minecraft.inventory.IInventory;
 import net.minecraft.tags.ITagCollection;
 import net.minecraft.tags.ITagCollectionSupplier;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.fml.common.thread.EffectiveSide;
 import org.apache.logging.log4j.LogManager;
@@ -54,11 +52,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerContainerEvent;
 import net.minecraftforge.fml.config.ConfigTracker;
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_16_R3.event.CraftEventFactory;
-import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
-import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryView;
-import org.bukkit.event.inventory.InventoryType;
 
 public class NetworkHooks
 {
@@ -227,23 +220,6 @@ public class NetworkHooks
             throw new IllegalArgumentException("Invalid PacketBuffer for openGui, found "+ output.readableBytes()+ " bytes");
         }
         Container c = containerSupplier.createMenu(openContainerId, player.inventory, player);
-        if (c.getBukkitView() == null)
-        {
-            TileEntity tileEntity = player.world.getTileEntity(output.readBlockPos());
-            if (tileEntity instanceof IInventory)
-            {
-                CraftInventory inventory = new CraftInventory((IInventory)tileEntity);
-                c.setBukkitView(new CraftInventoryView(player.getBukkitEntity(), inventory, c));
-            }
-            else
-            {
-                c.setBukkitView(new CraftInventoryView(player.getBukkitEntity(), Bukkit.createInventory(player.getBukkitEntity(), InventoryType.CHEST), c));
-            }
-        }
-        c = CraftEventFactory.callInventoryOpenEvent(player, c, false);
-        if (c == null) {
-            return;
-        }
         ContainerType<?> type = c.getType();
         FMLPlayMessages.OpenContainer msg = new FMLPlayMessages.OpenContainer(type, openContainerId, containerSupplier.getDisplayName(), output);
         FMLNetworkConstants.playChannel.sendTo(msg, player.connection.getNetworkManager(), NetworkDirection.PLAY_TO_CLIENT);


### PR DESCRIPTION
This PR:
1. Reverts NetworkHooks changes made in 2f046a35adb6bed2e3f90fc6f565dc4f030fe5f8 as they break almost all mod TileEntities with inventories.
2. Fixes flawed "if" statement in ShapelessRecipe class, it was preventing mod recipes with isSimple == false from working.