### PR TITLE
Completely fixes #768 (sample drill)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -638,7 +638,7 @@
           return null;
        } else {
 +         // CraftBukkit start - Capture drops for death event
-+         if (this instanceof LivingEntity && !((LivingEntity) this).forceDrops) {
++         if (this instanceof LivingEntity && !((LivingEntity) this).forceDrops && ((LivingEntity) this).func_110143_aJ() == 0) {
 +            ((LivingEntity) this).drops.add(org.bukkit.craftbukkit.v1_16_R3.inventory.CraftItemStack.asCraftMirror(p_70099_1_));
 +            return null;
 +         }


### PR DESCRIPTION
This PR fixes sample drill drop by preventing drop caching if entity health is > 0 (fully closes issue #768)
Excavator apparently started working sometime earlier and doesn't need a fix anymore.