### PR TITLE
World-related changes

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -223,7 +223,12 @@
        ServerWorld serverworld = new ServerWorld(this, this.field_213217_au, this.field_71310_m, iserverworldinfo, World.field_234918_g_, dimensiontype, p_240787_1_, chunkgenerator, flag, j, list, true);
        this.field_71305_c.put(World.field_234918_g_, serverworld);
        DimensionSavedDataManager dimensionsaveddatamanager = serverworld.func_217481_x();
-@@ -375,9 +431,19 @@
+@@ -371,13 +427,23 @@
+             RegistryKey<World> registrykey1 = RegistryKey.func_240903_a_(Registry.field_239699_ae_, registrykey.func_240901_a_());
+             DimensionType dimensiontype1 = entry.getValue().func_236063_b_();
+             ChunkGenerator chunkgenerator1 = entry.getValue().func_236064_c_();
+-            DerivedWorldInfo derivedworldinfo = new DerivedWorldInfo(this.field_240768_i_, iserverworldinfo);
++            DerivedWorldInfo derivedworldinfo = new DerivedWorldInfo(this.field_240768_i_, iserverworldinfo, DimensionType.func_236031_a_(registrykey1, this.field_71310_m.getWorldDir().toFile()).getName());
              ServerWorld serverworld1 = new ServerWorld(this, this.field_213217_au, this.field_71310_m, derivedworldinfo, registrykey1, dimensiontype1, p_240787_1_, chunkgenerator1, flag, j, ImmutableList.of(), false);
              worldborder.func_177737_a(new IBorderListener.Impl(serverworld1.func_175723_af()));
              this.field_71305_c.put(registrykey1, serverworld1);

--- a/patches/minecraft/net/minecraft/world/storage/DerivedWorldInfo.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/DerivedWorldInfo.java.patch
@@ -1,0 +1,27 @@
+--- a/net/minecraft/world/storage/DerivedWorldInfo.java
++++ b/net/minecraft/world/storage/DerivedWorldInfo.java
+@@ -13,7 +13,15 @@
+ public class DerivedWorldInfo implements IServerWorldInfo {
+    private final IServerConfiguration field_237244_a_;
+    private final IServerWorldInfo field_76115_a;
++   private String properName;
+ 
++   public DerivedWorldInfo(IServerConfiguration configuration, IServerWorldInfo delegate, String properName) {
++       this.field_237244_a_ = configuration;
++       this.field_76115_a = delegate;
++       this.properName = properName;
++   }
++
++   @Deprecated
+    public DerivedWorldInfo(IServerConfiguration p_i232150_1_, IServerWorldInfo p_i232150_2_) {
+       this.field_237244_a_ = p_i232150_1_;
+       this.field_76115_a = p_i232150_2_;
+@@ -44,7 +52,7 @@
+    }
+ 
+    public String func_76065_j() {
+-      return this.field_237244_a_.func_76065_j();
++      return properName != null ? properName : this.field_237244_a_.func_76065_j();
+    }
+ 
+    public int func_230395_g_() {

--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/entity/CraftPlayer.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/entity/CraftPlayer.java
@@ -67,6 +67,8 @@ import net.minecraft.world.GameType;
 import net.minecraft.world.server.ChunkManager;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraft.world.storage.MapDecoration;
+import net.minecraftforge.common.util.ITeleporter;
+
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.Validate;
 import org.bukkit.BanList;
@@ -689,11 +691,18 @@ public class CraftPlayer extends org.bukkit.craftbukkit.v1_16_R3.entity.CraftHum
         }
 
         // Check if the fromWorld and toWorld are the same.
-        if (fromWorld == toWorld) {
+        /* if (fromWorld == toWorld) {
             entity.connection.teleport(to);
         } else {
             server.getHandle().moveToWorld(entity, toWorld, true, to, true);
-        }
+        } */
+
+        // Current implementation of 'moveToWorld' does not
+        // work properly. Luckily, 'changeDimension' with
+        // dummy teleporter does the same thing, but right.
+        if (fromWorld != toWorld)
+            entity.changeDimension(toWorld, new ITeleporter() {});
+        entity.connection.teleport(to);
         return true;
     }
 

--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/util/WorldUUID.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/util/WorldUUID.java
@@ -36,6 +36,7 @@ public final class WorldUUID {
                 }
             }
         }
+        baseDir.mkdirs();
         UUID uuid = UUID.randomUUID();
         DataOutputStream dos = null;
         try {


### PR DESCRIPTION
1. a0a3c5a **Avoid uid.dat exception when creating worlds**
The file was being created without verifying if parent directories even exist.
This caused problems and console spam during world creation.
2. 2c7a711 **Fix broken CraftBukkit world change**
_moveToWorld_ method for some reason is not working correctly. Probably outdated.
Instead of having a hard time debugging it, I went the other way and used _changeDimension_, which works perfectly fine.
3. 456f5b3 **Name worlds after their directories**
Before, name of every game world was simply... 'world'. This caused major problems in Essentials/Multiverse and basically any other plugin that somehow interacts with Bukkit's world/location API.
Now, worlds are named after the directories they reside in, just like in Thermos.