### PR TITLE
Implement entity/tile tick skipping (reup of #805)

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -1,9 +1,10 @@
 --- a/net/minecraft/world/World.java
 +++ b/net/minecraft/world/World.java
-@@ -1,11 +1,15 @@
+@@ -1,11 +1,16 @@
  package net.minecraft.world;
  
  import com.google.common.collect.Lists;
++import com.mohistmc.configuration.TickConfig;
 +import com.mohistmc.forge.ForgeInjectBukkit;
  import com.mojang.serialization.Codec;
  import java.io.IOException;
@@ -16,7 +17,7 @@
  import java.util.Random;
  import java.util.function.Consumer;
  import java.util.function.Predicate;
-@@ -20,6 +24,7 @@
+@@ -20,6 +25,7 @@
  import net.minecraft.crash.ReportedException;
  import net.minecraft.entity.Entity;
  import net.minecraft.entity.EntityType;
@@ -24,7 +25,7 @@
  import net.minecraft.entity.player.PlayerEntity;
  import net.minecraft.fluid.FluidState;
  import net.minecraft.fluid.Fluids;
-@@ -27,6 +32,7 @@
+@@ -27,6 +33,7 @@
  import net.minecraft.item.crafting.RecipeManager;
  import net.minecraft.nbt.CompoundNBT;
  import net.minecraft.network.IPacket;
@@ -32,7 +33,7 @@
  import net.minecraft.particles.IParticleData;
  import net.minecraft.profiler.IProfiler;
  import net.minecraft.scoreboard.Scoreboard;
-@@ -34,7 +40,6 @@
+@@ -34,7 +41,6 @@
  import net.minecraft.tags.ITagCollectionSupplier;
  import net.minecraft.tileentity.ITickableTileEntity;
  import net.minecraft.tileentity.TileEntity;
@@ -40,7 +41,7 @@
  import net.minecraft.util.DamageSource;
  import net.minecraft.util.Direction;
  import net.minecraft.util.RegistryKey;
-@@ -47,6 +52,7 @@
+@@ -47,6 +53,7 @@
  import net.minecraft.util.registry.Registry;
  import net.minecraft.world.biome.Biome;
  import net.minecraft.world.biome.BiomeManager;
@@ -48,7 +49,7 @@
  import net.minecraft.world.border.WorldBorder;
  import net.minecraft.world.chunk.AbstractChunkProvider;
  import net.minecraft.world.chunk.Chunk;
-@@ -55,15 +61,25 @@
+@@ -55,15 +62,25 @@
  import net.minecraft.world.gen.Heightmap;
  import net.minecraft.world.lighting.WorldLightManager;
  import net.minecraft.world.server.ChunkHolder;
@@ -75,7 +76,7 @@
     protected static final Logger field_195596_d = LogManager.getLogger();
     public static final Codec<RegistryKey<World>> field_234917_f_ = ResourceLocation.field_240908_a_.xmap(RegistryKey.func_240902_a_(Registry.field_239699_ae_), RegistryKey::func_240901_a_);
     public static final RegistryKey<World> field_234918_g_ = RegistryKey.func_240903_a_(Registry.field_239699_ae_, new ResourceLocation("overworld"));
-@@ -73,8 +89,8 @@
+@@ -73,8 +90,8 @@
     public final List<TileEntity> field_147482_g = Lists.newArrayList();
     public final List<TileEntity> field_175730_i = Lists.newArrayList();
     protected final List<TileEntity> field_147484_a = Lists.newArrayList();
@@ -86,7 +87,7 @@
     private final boolean field_234916_c_;
     private int field_73008_k;
     protected int field_73005_l = (new Random()).nextInt();
-@@ -85,15 +101,77 @@
+@@ -85,15 +102,77 @@
     public float field_73017_q;
     public final Random field_73012_v = new Random();
     private final DimensionType field_234921_x_;
@@ -165,7 +166,7 @@
        this.field_72984_F = p_i241925_4_;
        this.field_72986_A = p_i241925_1_;
        this.field_234921_x_ = p_i241925_3_;
-@@ -116,6 +194,10 @@
+@@ -116,6 +195,10 @@
        this.field_217407_c = Thread.currentThread();
        this.field_226689_w_ = new BiomeManager(this, p_i241925_7_, p_i241925_3_.func_227176_e_());
        this.field_234916_c_ = p_i241925_6_;
@@ -176,7 +177,7 @@
     }
  
     public boolean func_201670_d() {
-@@ -173,6 +255,17 @@
+@@ -173,6 +256,17 @@
     }
  
     public boolean func_241211_a_(BlockPos p_241211_1_, BlockState p_241211_2_, int p_241211_3_, int p_241211_4_) {
@@ -194,7 +195,7 @@
        if (func_189509_E(p_241211_1_)) {
           return false;
        } else if (!this.field_72995_K && this.func_234925_Z_()) {
-@@ -180,17 +273,66 @@
+@@ -180,17 +274,66 @@
        } else {
           Chunk chunk = this.func_175726_f(p_241211_1_);
           Block block = p_241211_2_.func_177230_c();
@@ -263,7 +264,7 @@
              if (blockstate1 == p_241211_2_) {
                 if (blockstate != blockstate1) {
                    this.func_225319_b(p_241211_1_, blockstate, blockstate1);
-@@ -210,14 +352,24 @@
+@@ -210,14 +353,24 @@
                 if ((p_241211_3_ & 16) == 0 && p_241211_4_ > 0) {
                    int i = p_241211_3_ & -34;
                    blockstate.func_241483_b_(this, p_241211_1_, i, p_241211_4_ - 1);
@@ -290,7 +291,7 @@
           }
        }
     }
-@@ -232,7 +384,7 @@
+@@ -232,7 +385,7 @@
  
     public boolean func_241212_a_(BlockPos p_241212_1_, boolean p_241212_2_, @Nullable Entity p_241212_3_, int p_241212_4_) {
        BlockState blockstate = this.func_180495_p(p_241212_1_);
@@ -299,7 +300,7 @@
           return false;
        } else {
           FluidState fluidstate = this.func_204610_c(p_241212_1_);
-@@ -241,7 +393,7 @@
+@@ -241,7 +394,7 @@
           }
  
           if (p_241212_2_) {
@@ -308,7 +309,7 @@
              Block.func_220054_a(blockstate, this, p_241212_1_, tileentity, p_241212_3_, ItemStack.field_190927_a);
           }
  
-@@ -259,6 +411,9 @@
+@@ -259,6 +412,9 @@
     }
  
     public void func_195593_d(BlockPos p_195593_1_, Block p_195593_2_) {
@@ -318,7 +319,7 @@
        this.func_190524_a(p_195593_1_.func_177976_e(), p_195593_2_, p_195593_1_);
        this.func_190524_a(p_195593_1_.func_177974_f(), p_195593_2_, p_195593_1_);
        this.func_190524_a(p_195593_1_.func_177977_b(), p_195593_2_, p_195593_1_);
-@@ -268,6 +423,11 @@
+@@ -268,6 +424,11 @@
     }
  
     public void func_175695_a(BlockPos p_175695_1_, Block p_175695_2_, Direction p_175695_3_) {
@@ -330,7 +331,7 @@
        if (p_175695_3_ != Direction.WEST) {
           this.func_190524_a(p_175695_1_.func_177976_e(), p_175695_2_, p_175695_1_);
        }
-@@ -299,15 +459,29 @@
+@@ -299,15 +460,29 @@
           BlockState blockstate = this.func_180495_p(p_190524_1_);
  
           try {
@@ -362,7 +363,7 @@
                 }
              });
              CrashReportCategory.func_175750_a(crashreportcategory, p_190524_1_, blockstate);
-@@ -336,6 +510,14 @@
+@@ -336,6 +511,14 @@
     }
  
     public BlockState func_180495_p(BlockPos p_180495_1_) {
@@ -377,7 +378,7 @@
        if (func_189509_E(p_180495_1_)) {
           return Blocks.field_201940_ji.func_176223_P();
        } else {
-@@ -391,10 +573,12 @@
+@@ -391,10 +574,12 @@
     }
  
     public boolean func_175700_a(TileEntity p_175700_1_) {
@@ -390,7 +391,7 @@
        }
  
        boolean flag = this.field_147482_g.add(p_175700_1_);
-@@ -402,6 +586,8 @@
+@@ -402,6 +587,8 @@
           this.field_175730_i.add(p_175700_1_);
        }
  
@@ -399,7 +400,7 @@
        if (this.field_72995_K) {
           BlockPos blockpos = p_175700_1_.func_174877_v();
           BlockState blockstate = this.func_180495_p(blockpos);
-@@ -413,6 +599,7 @@
+@@ -413,6 +600,7 @@
  
     public void func_147448_a(Collection<TileEntity> p_147448_1_) {
        if (this.field_147481_N) {
@@ -407,7 +408,7 @@
           this.field_147484_a.addAll(p_147448_1_);
        } else {
           for(TileEntity tileentity : p_147448_1_) {
-@@ -425,24 +612,43 @@
+@@ -425,24 +613,43 @@
     public void func_217391_K() {
        IProfiler iprofiler = this.func_217381_Z();
        iprofiler.func_76320_a("blockEntities");
@@ -447,7 +448,8 @@
 +         // Spigot end
           if (!tileentity.func_145837_r() && tileentity.func_145830_o()) {
              BlockPos blockpos = tileentity.func_174877_v();
-             if (this.func_72863_F().func_222866_a(blockpos) && this.func_175723_af().func_177746_a(blockpos)) {
+-            if (this.func_72863_F().func_222866_a(blockpos) && this.func_175723_af().func_177746_a(blockpos)) {
++            if (TickConfig.TILES.canTick(tileentity.getClass(), this.func_82737_E()) && this.func_72863_F().func_222866_a(blockpos) && this.func_175723_af().func_177746_a(blockpos)) {
                 try {
 +                  net.minecraftforge.server.timings.TimeTracker.TILE_ENTITY_UPDATE.trackStart(tileentity);
                    iprofiler.func_194340_a(() -> {
@@ -458,7 +460,7 @@
                    if (tileentity.func_200662_C().func_223045_a(this.func_180495_p(blockpos).func_177230_c())) {
                       ((ITickableTileEntity)tileentity).func_73660_a();
                    } else {
-@@ -454,35 +660,60 @@
+@@ -454,35 +661,60 @@
                    CrashReport crashreport = CrashReport.func_85055_a(throwable, "Ticking block entity");
                    CrashReportCategory crashreportcategory = crashreport.func_85058_a("Block entity being ticked");
                    tileentity.func_145828_a(crashreportcategory);
@@ -523,7 +525,7 @@
                 }
              }
           }
-@@ -490,17 +721,24 @@
+@@ -490,17 +722,24 @@
           this.field_147484_a.clear();
        }
  
@@ -548,7 +550,7 @@
        }
     }
  
-@@ -514,6 +752,7 @@
+@@ -514,6 +753,7 @@
  
     public Explosion func_230546_a_(@Nullable Entity p_230546_1_, @Nullable DamageSource p_230546_2_, @Nullable ExplosionContext p_230546_3_, double p_230546_4_, double p_230546_6_, double p_230546_8_, float p_230546_10_, boolean p_230546_11_, Explosion.Mode p_230546_12_) {
        Explosion explosion = new Explosion(this, p_230546_1_, p_230546_2_, p_230546_3_, p_230546_4_, p_230546_6_, p_230546_8_, p_230546_10_, p_230546_11_, p_230546_12_);
@@ -556,7 +558,7 @@
        explosion.func_77278_a();
        explosion.func_77279_a(true);
        return explosion;
-@@ -525,22 +764,34 @@
+@@ -525,22 +765,34 @@
  
     @Nullable
     public TileEntity func_175625_s(BlockPos p_175625_1_) {
@@ -595,7 +597,7 @@
           }
  
           return tileentity;
-@@ -561,7 +812,15 @@
+@@ -561,7 +813,15 @@
  
     public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_) {
        if (!func_189509_E(p_175690_1_)) {
@@ -611,7 +613,7 @@
              if (this.field_147481_N) {
                 p_175690_2_.func_226984_a_(this, p_175690_1_);
                 Iterator<TileEntity> iterator = this.field_147484_a.iterator();
-@@ -576,7 +835,8 @@
+@@ -576,7 +836,8 @@
  
                 this.field_147484_a.add(p_175690_2_);
              } else {
@@ -621,7 +623,7 @@
                 this.func_175700_a(p_175690_2_);
              }
           }
-@@ -585,10 +845,12 @@
+@@ -585,10 +846,12 @@
     }
  
     public void func_175713_t(BlockPos p_175713_1_) {
@@ -635,7 +637,7 @@
        } else {
           if (tileentity != null) {
              this.field_147484_a.remove(tileentity);
-@@ -598,7 +860,7 @@
+@@ -598,7 +861,7 @@
  
           this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
        }
@@ -644,7 +646,7 @@
     }
  
     public boolean func_195588_v(BlockPos p_195588_1_) {
-@@ -651,10 +913,10 @@
+@@ -651,10 +914,10 @@
     public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate<? super Entity> p_175674_3_) {
        this.func_217381_Z().func_230035_c_("getEntities");
        List<Entity> list = Lists.newArrayList();
@@ -659,7 +661,7 @@
        AbstractChunkProvider abstractchunkprovider = this.func_72863_F();
  
        for(int i1 = i; i1 <= j; ++i1) {
-@@ -671,10 +933,10 @@
+@@ -671,10 +934,10 @@
  
     public <T extends Entity> List<T> func_217394_a(@Nullable EntityType<T> p_217394_1_, AxisAlignedBB p_217394_2_, Predicate<? super T> p_217394_3_) {
        this.func_217381_Z().func_230035_c_("getEntities");
@@ -674,7 +676,7 @@
        List<T> list = Lists.newArrayList();
  
        for(int i1 = i; i1 < j; ++i1) {
-@@ -691,10 +953,10 @@
+@@ -691,10 +954,10 @@
  
     public <T extends Entity> List<T> func_175647_a(Class<? extends T> p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate<? super T> p_175647_3_) {
        this.func_217381_Z().func_230035_c_("getEntities");
@@ -689,7 +691,7 @@
        List<T> list = Lists.newArrayList();
        AbstractChunkProvider abstractchunkprovider = this.func_72863_F();
  
-@@ -712,10 +974,10 @@
+@@ -712,10 +975,10 @@
  
     public <T extends Entity> List<T> func_225316_b(Class<? extends T> p_225316_1_, AxisAlignedBB p_225316_2_, @Nullable Predicate<? super T> p_225316_3_) {
        this.func_217381_Z().func_230035_c_("getLoadedEntities");
@@ -704,7 +706,7 @@
        List<T> list = Lists.newArrayList();
        AbstractChunkProvider abstractchunkprovider = this.func_72863_F();
  
-@@ -739,6 +1001,7 @@
+@@ -739,6 +1002,7 @@
           this.func_175726_f(p_175646_1_).func_76630_e();
        }
  
@@ -712,7 +714,7 @@
     }
  
     public int func_181545_F() {
-@@ -783,7 +1046,7 @@
+@@ -783,7 +1047,7 @@
     public int func_175651_c(BlockPos p_175651_1_, Direction p_175651_2_) {
        BlockState blockstate = this.func_180495_p(p_175651_1_);
        int i = blockstate.func_185911_a(this, p_175651_1_, p_175651_2_);
@@ -721,7 +723,7 @@
     }
  
     public boolean func_175640_z(BlockPos p_175640_1_) {
-@@ -938,16 +1201,15 @@
+@@ -938,16 +1202,15 @@
     public abstract Scoreboard func_96441_U();
  
     public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_) {
@@ -742,7 +744,7 @@
                    blockstate.func_215697_a(this, blockpos, p_175666_2_, p_175666_1_, false);
                 }
              }
-@@ -1024,7 +1286,27 @@
+@@ -1024,7 +1287,27 @@
        return this.field_226689_w_;
     }
  

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -1,14 +1,15 @@
 --- a/net/minecraft/world/server/ServerWorld.java
 +++ b/net/minecraft/world/server/ServerWorld.java
-@@ -6,6 +6,7 @@
+@@ -6,6 +6,8 @@
  import com.google.common.collect.Maps;
  import com.google.common.collect.Queues;
  import com.google.common.collect.Sets;
++import com.mohistmc.configuration.TickConfig;
 +import com.mohistmc.inventory.CraftCustomInventory;
  import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
  import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
  import it.unimi.dsi.fastutil.ints.Int2ObjectMap.Entry;
-@@ -18,19 +19,12 @@
+@@ -18,19 +20,12 @@
  import java.io.Writer;
  import java.nio.file.Files;
  import java.nio.file.Path;
@@ -30,7 +31,7 @@
  import java.util.stream.Collectors;
  import java.util.stream.Stream;
  import javax.annotation.Nonnull;
-@@ -39,6 +33,7 @@
+@@ -39,6 +34,7 @@
  import net.minecraft.block.BlockEventData;
  import net.minecraft.block.BlockState;
  import net.minecraft.block.Blocks;
@@ -38,7 +39,7 @@
  import net.minecraft.crash.CrashReport;
  import net.minecraft.entity.Entity;
  import net.minecraft.entity.EntityClassification;
-@@ -51,6 +46,8 @@
+@@ -51,6 +47,8 @@
  import net.minecraft.entity.effect.LightningBoltEntity;
  import net.minecraft.entity.merchant.IReputationTracking;
  import net.minecraft.entity.merchant.IReputationType;
@@ -47,7 +48,7 @@
  import net.minecraft.entity.passive.AnimalEntity;
  import net.minecraft.entity.passive.WaterMobEntity;
  import net.minecraft.entity.passive.horse.SkeletonHorseEntity;
-@@ -59,6 +56,7 @@
+@@ -59,6 +57,7 @@
  import net.minecraft.fluid.Fluid;
  import net.minecraft.fluid.FluidState;
  import net.minecraft.fluid.Fluids;
@@ -55,7 +56,7 @@
  import net.minecraft.item.crafting.RecipeManager;
  import net.minecraft.network.DebugPacketSender;
  import net.minecraft.network.IPacket;
-@@ -79,17 +77,7 @@
+@@ -79,17 +78,7 @@
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.tags.ITagCollectionSupplier;
  import net.minecraft.tileentity.TileEntity;
@@ -74,7 +75,7 @@
  import net.minecraft.util.math.AxisAlignedBB;
  import net.minecraft.util.math.BlockPos;
  import net.minecraft.util.math.ChunkPos;
-@@ -133,27 +121,32 @@
+@@ -133,27 +122,32 @@
  import net.minecraft.world.raid.RaidManager;
  import net.minecraft.world.spawner.ISpecialSpawner;
  import net.minecraft.world.spawner.WorldEntitySpawner;
@@ -115,7 +116,7 @@
     public boolean field_73058_d;
     private boolean field_73068_P;
     private int field_80004_Q;
-@@ -173,9 +166,31 @@
+@@ -173,9 +167,31 @@
     private final DragonFightManager field_241105_O_;
     private final StructureManager field_241106_P_;
     private final boolean field_241107_Q_;
@@ -147,7 +148,7 @@
        this.field_241107_Q_ = p_i241885_13_;
        this.field_73061_a = p_i241885_1_;
        this.field_241104_N_ = p_i241885_12_;
-@@ -200,9 +215,31 @@
+@@ -200,9 +216,31 @@
        } else {
           this.field_241105_O_ = null;
        }
@@ -179,7 +180,7 @@
     public void func_241113_a_(int p_241113_1_, int p_241113_2_, boolean p_241113_3_, boolean p_241113_4_) {
        this.field_241103_E_.func_230391_a_(p_241113_1_);
        this.field_241103_E_.func_76080_g(p_241113_2_);
-@@ -211,6 +248,7 @@
+@@ -211,6 +249,7 @@
        this.field_241103_E_.func_76069_a(p_241113_4_);
     }
  
@@ -187,7 +188,7 @@
     public Biome func_225604_a_(int p_225604_1_, int p_225604_2_, int p_225604_3_) {
        return this.func_72863_F().func_201711_g().func_202090_b().func_225526_b_(p_225604_1_, p_225604_2_, p_225604_3_);
     }
-@@ -296,27 +334,39 @@
+@@ -296,27 +335,39 @@
           this.field_73061_a.func_184103_al().func_232642_a_(new SChangeGameStatePacket(SChangeGameStatePacket.field_241772_i_, this.field_73017_q), this.func_234923_W_());
        }
  
@@ -236,7 +237,7 @@
           if (this.func_82736_K().func_223586_b(GameRules.field_223617_t)) {
              this.func_73051_P();
           }
-@@ -327,15 +377,19 @@
+@@ -327,15 +378,19 @@
        iprofiler.func_219895_b("chunkSource");
        this.func_72863_F().func_217207_a(p_72835_1_);
        iprofiler.func_219895_b("tickPending");
@@ -256,7 +257,7 @@
        this.field_211159_Q = false;
        iprofiler.func_219895_b("entities");
        boolean flag3 = !this.field_217491_A.isEmpty() || !this.func_217469_z().isEmpty();
-@@ -344,6 +398,7 @@
+@@ -344,6 +399,7 @@
        }
  
        if (flag3 || this.field_80004_Q++ < 300) {
@@ -264,7 +265,7 @@
           if (this.field_241105_O_ != null) {
              this.field_241105_O_.func_186105_b();
           }
-@@ -351,18 +406,22 @@
+@@ -351,18 +407,22 @@
           this.field_217492_a = true;
           ObjectIterator<Entry<Entity>> objectiterator = this.field_217498_x.int2ObjectEntrySet().iterator();
  
@@ -287,7 +288,7 @@
                    this.func_217391_K();
                    break label164;
                 }
-@@ -404,7 +463,7 @@
+@@ -404,7 +464,7 @@
              if (entity1.field_70128_L) {
                 this.func_217454_n(entity1);
                 objectiterator.remove();
@@ -296,7 +297,7 @@
              }
  
              iprofiler.func_76319_b();
-@@ -460,13 +519,13 @@
+@@ -460,13 +520,13 @@
                 skeletonhorseentity.func_190691_p(true);
                 skeletonhorseentity.func_70873_a(0);
                 skeletonhorseentity.func_70107_b((double)blockpos.func_177958_n(), (double)blockpos.func_177956_o(), (double)blockpos.func_177952_p());
@@ -312,7 +313,7 @@
           }
        }
  
-@@ -475,12 +534,13 @@
+@@ -475,12 +535,13 @@
           BlockPos blockpos2 = this.func_205770_a(Heightmap.Type.MOTION_BLOCKING, this.func_217383_a(i, 0, j, 15));
           BlockPos blockpos3 = blockpos2.func_177977_b();
           Biome biome = this.func_226691_t_(blockpos2);
@@ -328,7 +329,7 @@
           }
  
           if (flag && this.func_226691_t_(blockpos3).func_201851_b() == Biome.RainType.RAIN) {
-@@ -544,7 +604,7 @@
+@@ -544,7 +605,7 @@
           int j = 0;
  
           for(ServerPlayerEntity serverplayerentity : this.field_217491_A) {
@@ -337,7 +338,7 @@
                 ++i;
              } else if (serverplayerentity.func_70608_bn()) {
                 ++j;
-@@ -561,10 +621,22 @@
+@@ -561,10 +622,22 @@
     }
  
     private void func_73051_P() {
@@ -362,12 +363,12 @@
     }
  
     public void func_82742_i() {
-@@ -591,6 +663,14 @@
+@@ -591,6 +664,14 @@
        if (!(p_217479_1_ instanceof PlayerEntity) && !this.func_72863_F().func_217204_a(p_217479_1_)) {
           this.func_217464_b(p_217479_1_);
        } else {
 +         // Spigot start
-+         if (!org.spigotmc.ActivationRange.checkIfActive(p_217479_1_)) {
++         if (!TickConfig.ENTITIES.canTick(p_217479_1_.getClass(), this.func_82737_E()) || !org.spigotmc.ActivationRange.checkIfActive(p_217479_1_)) {
 +            p_217479_1_.field_70173_aa++;
 +            p_217479_1_.inactiveTick();
 +            return;
@@ -377,7 +378,7 @@
           p_217479_1_.func_226286_f_(p_217479_1_.func_226277_ct_(), p_217479_1_.func_226278_cu_(), p_217479_1_.func_226281_cx_());
           p_217479_1_.field_70126_B = p_217479_1_.field_70177_z;
           p_217479_1_.field_70127_C = p_217479_1_.field_70125_A;
-@@ -598,10 +678,12 @@
+@@ -598,10 +679,12 @@
              ++p_217479_1_.field_70173_aa;
              IProfiler iprofiler = this.func_217381_Z();
              iprofiler.func_194340_a(() -> {
@@ -391,7 +392,7 @@
              iprofiler.func_76319_b();
           }
  
-@@ -611,6 +693,7 @@
+@@ -611,6 +694,7 @@
                 this.func_217459_a(p_217479_1_, entity);
              }
           }
@@ -399,7 +400,7 @@
  
        }
     }
-@@ -629,6 +712,7 @@
+@@ -629,6 +713,7 @@
                 });
                 iprofiler.func_230035_c_("tickPassenger");
                 p_217459_2_.func_70098_U();
@@ -407,7 +408,7 @@
                 iprofiler.func_76319_b();
              }
  
-@@ -649,7 +733,7 @@
+@@ -649,7 +734,7 @@
        if (p_217464_1_.func_233578_ci_()) {
           this.func_217381_Z().func_76320_a("chunkCheck");
           int i = MathHelper.func_76128_c(p_217464_1_.func_226277_ct_() / 16.0D);
@@ -416,7 +417,7 @@
           int k = MathHelper.func_76128_c(p_217464_1_.func_226281_cx_() / 16.0D);
           if (!p_217464_1_.field_70175_ag || p_217464_1_.field_70176_ah != i || p_217464_1_.field_70162_ai != j || p_217464_1_.field_70164_aj != k) {
              if (p_217464_1_.field_70175_ag && this.func_217354_b(p_217464_1_.field_70176_ah, p_217464_1_.field_70164_aj)) {
-@@ -658,7 +742,7 @@
+@@ -658,7 +743,7 @@
  
              if (!p_217464_1_.func_233577_ch_() && !this.func_217354_b(i, k)) {
                 if (p_217464_1_.field_70175_ag) {
@@ -425,7 +426,7 @@
                 }
  
                 p_217464_1_.field_70175_ag = false;
-@@ -678,6 +762,7 @@
+@@ -678,6 +763,7 @@
     public void func_217445_a(@Nullable IProgressUpdate p_217445_1_, boolean p_217445_2_, boolean p_217445_3_) {
        ServerChunkProvider serverchunkprovider = this.func_72863_F();
        if (!p_217445_3_) {
@@ -433,7 +434,7 @@
           if (p_217445_1_ != null) {
              p_217445_1_.func_200210_a(new TranslationTextComponent("menu.savingLevel"));
           }
-@@ -687,6 +772,7 @@
+@@ -687,6 +773,7 @@
              p_217445_1_.func_200209_c(new TranslationTextComponent("menu.savingChunks"));
           }
  
@@ -441,7 +442,7 @@
           serverchunkprovider.func_217210_a(p_217445_2_);
        }
     }
-@@ -743,13 +829,23 @@
+@@ -743,13 +830,23 @@
     }
  
     public boolean func_217376_c(Entity p_217376_1_) {
@@ -467,7 +468,7 @@
     public void func_217460_e(Entity p_217460_1_) {
        boolean flag = p_217460_1_.field_98038_p;
        p_217460_1_.field_98038_p = true;
-@@ -777,9 +873,10 @@
+@@ -777,9 +874,10 @@
     }
  
     private void func_217448_f(ServerPlayerEntity p_217448_1_) {
@@ -479,7 +480,7 @@
           entity.func_213319_R();
           this.func_217434_e((ServerPlayerEntity)entity);
        }
-@@ -795,18 +892,24 @@
+@@ -795,18 +893,24 @@
     }
  
     private boolean func_72838_d(Entity p_72838_1_) {
@@ -510,7 +511,7 @@
              return true;
           }
        }
-@@ -816,6 +919,7 @@
+@@ -816,6 +920,7 @@
        if (this.func_217478_l(p_217440_1_)) {
           return false;
        } else {
@@ -518,7 +519,7 @@
           this.func_217465_m(p_217440_1_);
           return true;
        }
-@@ -827,7 +931,7 @@
+@@ -827,7 +932,7 @@
        if (entity == null) {
           return false;
        } else {
@@ -527,7 +528,7 @@
           return true;
        }
     }
-@@ -851,15 +955,30 @@
+@@ -851,15 +956,30 @@
     }
  
     public boolean func_242106_g(Entity p_242106_1_) {
@@ -560,7 +561,7 @@
        this.field_147483_b.addAll(p_217466_1_.func_177434_r().values());
        ClassInheritanceMultiMap<Entity>[] aclassinheritancemultimap = p_217466_1_.func_177429_s();
        int i = aclassinheritancemultimap.length;
-@@ -879,12 +998,41 @@
+@@ -879,12 +999,41 @@
  
     }
  
@@ -603,7 +604,7 @@
  
        this.field_175741_N.remove(p_217484_1_.func_110124_au());
        this.func_72863_F().func_217226_b(p_217484_1_);
-@@ -894,10 +1042,19 @@
+@@ -894,10 +1043,19 @@
        }
  
        this.func_96441_U().func_181140_a(p_217484_1_);
@@ -623,7 +624,7 @@
     }
  
     private void func_217465_m(Entity p_217465_1_) {
-@@ -913,20 +1070,31 @@
+@@ -913,20 +1071,31 @@
  
           this.field_175741_N.put(p_217465_1_.func_110124_au(), p_217465_1_);
           this.func_72863_F().func_217230_c(p_217465_1_);
@@ -656,7 +657,7 @@
        }
     }
  
-@@ -939,17 +1107,47 @@
+@@ -939,17 +1108,47 @@
     }
  
     public void func_217434_e(ServerPlayerEntity p_217434_1_) {
@@ -706,7 +707,7 @@
              if (d0 * d0 + d1 * d1 + d2 * d2 < 1024.0D) {
                 serverplayerentity.field_71135_a.func_147359_a(new SAnimateBlockBreakPacket(p_175715_1_, p_175715_2_, p_175715_3_));
              }
-@@ -959,10 +1157,20 @@
+@@ -959,10 +1158,20 @@
     }
  
     public void func_184148_a(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {
@@ -727,7 +728,7 @@
        this.field_73061_a.func_184103_al().func_148543_a(p_217384_1_, p_217384_2_.func_226277_ct_(), p_217384_2_.func_226278_cu_(), p_217384_2_.func_226281_cx_(), p_217384_5_ > 1.0F ? (double)(16.0F * p_217384_5_) : 16.0D, this.func_234923_W_(), new SSpawnMovingSoundEffectPacket(p_217384_3_, p_217384_4_, p_217384_2_, p_217384_5_, p_217384_6_));
     }
  
-@@ -997,9 +1205,17 @@
+@@ -997,9 +1206,17 @@
     }
  
     public Explosion func_230546_a_(@Nullable Entity p_230546_1_, @Nullable DamageSource p_230546_2_, @Nullable ExplosionContext p_230546_3_, double p_230546_4_, double p_230546_6_, double p_230546_8_, float p_230546_10_, boolean p_230546_11_, Explosion.Mode p_230546_12_) {
@@ -748,7 +749,7 @@
        if (p_230546_12_ == Explosion.Mode.NONE) {
           explosion.func_180342_d();
        }
-@@ -1054,12 +1270,19 @@
+@@ -1054,12 +1271,19 @@
     }
  
     public <T extends IParticleData> int func_195598_a(T p_195598_1_, double p_195598_2_, double p_195598_4_, double p_195598_6_, int p_195598_8_, double p_195598_9_, double p_195598_11_, double p_195598_13_, double p_195598_15_) {
@@ -770,7 +771,7 @@
              ++i;
           }
        }
-@@ -1131,7 +1354,13 @@
+@@ -1131,7 +1355,13 @@
     @Nullable
     public MapData func_217406_a(String p_217406_1_) {
        return this.func_73046_m().func_241755_D_().func_217481_x().func_215753_b(() -> {
@@ -785,7 +786,7 @@
        }, p_217406_1_);
     }
  
-@@ -1333,6 +1562,11 @@
+@@ -1333,6 +1563,11 @@
  
     public void func_230547_a_(BlockPos p_230547_1_, Block p_230547_2_) {
        if (!this.func_234925_Z_()) {
@@ -797,7 +798,7 @@
           this.func_195593_d(p_230547_1_, p_230547_2_);
        }
  
-@@ -1399,15 +1633,44 @@
+@@ -1399,15 +1634,44 @@
     }
  
     public static void func_241121_a_(ServerWorld p_241121_0_) {

--- a/src/main/java/com/mohistmc/command/MohistCommand.java
+++ b/src/main/java/com/mohistmc/command/MohistCommand.java
@@ -3,6 +3,7 @@ package com.mohistmc.command;
 import com.mohistmc.api.PlayerAPI;
 import com.mohistmc.api.ServerAPI;
 import com.mohistmc.configuration.MohistConfig;
+import com.mohistmc.configuration.TickConfig;
 import com.mohistmc.util.i18n.i18n;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -91,8 +92,11 @@ public class MohistCommand extends Command {
                 }
                 break;
             case "reload":
-                MohistConfig.instance.load();
-                sender.sendMessage(ChatColor.GREEN + "mohist.yml reload complete.");
+                if (MohistConfig.instance != null)
+                    MohistConfig.instance.load();
+                TickConfig.ENTITIES.reloadConfig();
+                TickConfig.TILES.reloadConfig();
+                sender.sendMessage(ChatColor.GREEN + "mohist-config directory reload complete.");
                 break;
             default:
                 sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);

--- a/src/main/java/com/mohistmc/configuration/TickConfig.java
+++ b/src/main/java/com/mohistmc/configuration/TickConfig.java
@@ -1,0 +1,162 @@
+package com.mohistmc.configuration;
+
+import java.io.File;
+import java.util.HashMap;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+public class TickConfig {
+
+    /**
+     * Default tick params if nothing to load
+     */
+    private static final TickParams DEFAULT_TICK_PARAMS;
+
+    /**
+     * Config section for default tick params
+     */
+    private static final String DEFAULTS_SEC;
+
+    /**
+     * Config section for overridden params
+     */
+    private static final String OVERRIDES_SEC;
+
+    /**
+     * Config key for 'skipEvery' tick field
+     */
+    private static final String SKIP_EVERY_KEY;
+
+    /**
+     * Config value indicating field is inherited
+     */
+    private static final String DEFAULT_VAL;
+
+    /**
+     * Class instance for entities
+     */
+    public static final TickConfig ENTITIES;
+
+    /**
+     * Class instance for tiles
+     */
+    public static final TickConfig TILES;
+
+    static {
+        DEFAULT_TICK_PARAMS = new TickParams();
+        DEFAULT_TICK_PARAMS.skipEvery = 0;
+        DEFAULTS_SEC = "defaults";
+        OVERRIDES_SEC = "overrides";
+        SKIP_EVERY_KEY = "skip-every";
+        DEFAULT_VAL = "default";
+        ENTITIES = new TickConfig("entities.yml", "entity");
+        TILES = new TickConfig("tiles.yml", "tile");
+    }
+
+    public boolean canTick(Class<?> clazz, long gametime) {
+        TickParams params = paramsMap.get(clazz);
+        if (params == null) {
+            if (cfg == null) reloadConfig();
+            params = new TickParams();
+            params.skipEvery = defaultLoadedParams.skipEvery;
+            paramsMap.put(clazz, params);
+            cfg.set(OVERRIDES_SEC + "." + formatClazz(clazz) + "." + SKIP_EVERY_KEY, DEFAULT_VAL);
+            saveConfig();
+        }
+        return params.skipEvery == 0 || gametime % params.skipEvery != 0;
+    }
+
+    public void reloadConfig() {
+        paramsMap.clear();
+        cfg = YamlConfiguration.loadConfiguration(cfgfile);
+        if (cfgfile.exists()) {
+            ConfigurationSection defaultsSec = cfg.getConfigurationSection(DEFAULTS_SEC);
+            if (defaultsSec == null) {
+                defaultLoadedParams = new TickParams();
+                defaultLoadedParams.skipEvery = DEFAULT_TICK_PARAMS.skipEvery;
+            }
+            else defaultLoadedParams = parseTickParams(defaultsSec);
+            ConfigurationSection overridesSec = cfg.getConfigurationSection(OVERRIDES_SEC);
+            if (overridesSec != null) {
+                for (String override : overridesSec.getKeys(false)) {
+                    ConfigurationSection overrideSec = overridesSec.getConfigurationSection(override);
+                    if (overrideSec != null) {
+                        try {
+                            Class<?> overrideCls = Class.forName(unformatClazz(override));
+                            TickParams params = parseTickParams(overrideSec);
+                            paramsMap.put(overrideCls, params);
+                        } catch (Exception e) {}
+                    }
+                }
+            }
+        }
+        else {
+            cfg.options().header(
+                "Welcome to Mohist " + typename + " tick configuration!\n"
+                + "This opens up good TPS savings if used wisely.\n"
+                + "'" + OVERRIDES_SEC + "' section populates itself over time.\n"
+                + "-=-=-=-=-\n"
+                + "Simple usage cases:\n"
+                + "'" + SKIP_EVERY_KEY + ": 50' - skips every 50th tick\n"
+                + "'" + SKIP_EVERY_KEY + ": 0' - tick limiter is not applied (vanilla behaviour)\n"
+                + "'" + SKIP_EVERY_KEY + ": 1' - " + typename + " will not tick at all (skips every 1st tick)\n"
+                + "'" + SKIP_EVERY_KEY + ": " + DEFAULT_VAL + "' - value is grabbed from '" + DEFAULTS_SEC + "' section\n"
+                + "Values in range of 0 up to 1000 can be used, you won't need more than that.\n"
+                + "-=-=-=-=-\n"
+            );
+            defaultLoadedParams = new TickParams();
+            defaultLoadedParams.skipEvery = DEFAULT_TICK_PARAMS.skipEvery;
+            ConfigurationSection defaultsSec = cfg.createSection("defaults");
+            defaultsSec.set(SKIP_EVERY_KEY, defaultLoadedParams.skipEvery);
+            cfg.createSection("overrides");
+            saveConfig();
+        }
+    }
+
+    private TickParams parseTickParams(ConfigurationSection sec) {
+        TickParams params = new TickParams();
+        if (sec.isInt(SKIP_EVERY_KEY)) {
+            int skipEvery = sec.getInt(SKIP_EVERY_KEY);
+            if (skipEvery > 1000) skipEvery = 1000;
+            if (skipEvery < 0) skipEvery = 0;
+            params.skipEvery = skipEvery;
+        }
+        else {
+            if (sec.getParent().getName().equals(OVERRIDES_SEC))
+                params.skipEvery = defaultLoadedParams.skipEvery;
+            else
+                params.skipEvery = DEFAULT_TICK_PARAMS.skipEvery;
+        }
+        return params;
+    }
+
+    private String formatClazz(Class<?> clazz) {
+        return clazz.getName().replace('.', '-');
+    }
+
+    private String unformatClazz(String clazz) {
+        return clazz.replace('-', '.');
+    }
+
+    private void saveConfig() {
+        try {
+        cfg.save(cfgfile);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private final File cfgfile;
+    private final String typename;
+    private final HashMap<Class<?>, TickParams> paramsMap;
+    private YamlConfiguration cfg;
+    private TickParams defaultLoadedParams;
+
+    private TickConfig(String filename, String typename) {
+        this.cfgfile = new File("mohist-config", filename);
+        this.typename = typename;
+        this.paramsMap = new HashMap<>();
+    }
+
+}

--- a/src/main/java/com/mohistmc/configuration/TickParams.java
+++ b/src/main/java/com/mohistmc/configuration/TickParams.java
@@ -1,0 +1,9 @@
+package com.mohistmc.configuration;
+
+public class TickParams {
+
+    protected int skipEvery;
+
+    protected TickParams() {}
+
+}


### PR DESCRIPTION
This is a reupload of PR #805, as it had a bad timing with branch deletion.
---
I've really liked Thermos' config-driven tick limitation system since I discovered it - it allows for a flexible performance optimizations. So I went and reimplemented the similar thing for Mohist :)
Two new configs will appear in mohist-config directory: entities.yml and tiles.yml - in both of them you'll find a small guide with simple examples, explaining how to use the system. The rest is pretty self-explanatory.