### PR TITLE
Befriend Material remapping with Forge

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/legacy/CraftLegacy.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/legacy/CraftLegacy.java
@@ -219,8 +219,10 @@ public final class CraftLegacy {
     }
 
     public static Material[] values() {
-        Material[] values = Material.values();
-        return Arrays.copyOfRange(values, Material.LEGACY_AIR.ordinal(), values.length);
+        Material[] materials = Material.values();
+        Material[] legacyWithForge = new Material[materials.length - CraftMagicNumbers.LEGACY_FIRST_POS];
+        System.arraycopy(materials, CraftMagicNumbers.LEGACY_FIRST_POS, legacyWithForge, 0, legacyWithForge.length);
+        return legacyWithForge;
     }
 
     public static Material valueOf(String name) {
@@ -236,9 +238,10 @@ public final class CraftLegacy {
     }
 
     public static int ordinal(Material material) {
-        Preconditions.checkArgument(material.isLegacy(), "ordinal on modern Material");
+        // Mohist: Forge Materials are modern, so remove the check
+        // Preconditions.checkArgument(material.isLegacy(), "ordinal on modern Material");
 
-        return material.ordinal() - Material.LEGACY_AIR.ordinal();
+        return material.ordinal() - CraftMagicNumbers.LEGACY_FIRST_POS;
     }
 
     public static String name(Material material) {

--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/util/CraftLegacy.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/util/CraftLegacy.java
@@ -27,8 +27,11 @@ public final class CraftLegacy {
     }
 
     public static Material[] modern_values() {
-        Material[] values = Material.values();
-        return Arrays.copyOfRange(values, 0, Material.LEGACY_AIR.ordinal());
+        Material[] materials = Material.values();
+        Material[] modernWithForge = new Material[materials.length - (CraftMagicNumbers.LEGACY_LAST_POS - CraftMagicNumbers.LEGACY_FIRST_POS + 1)];
+        System.arraycopy(materials, 0, modernWithForge, 0, CraftMagicNumbers.LEGACY_FIRST_POS);
+        System.arraycopy(materials, CraftMagicNumbers.LEGACY_LAST_POS + 1, modernWithForge, CraftMagicNumbers.LEGACY_FIRST_POS, materials.length - CraftMagicNumbers.LEGACY_LAST_POS - 1);
+        return modernWithForge;
     }
 
     public static int modern_ordinal(Material material) {
@@ -37,6 +40,12 @@ public final class CraftLegacy {
             throw new NoSuchFieldError("Legacy field ordinal: " + material);
         }
 
-        return material.ordinal();
+        int ord = material.ordinal();
+        if (ord > CraftMagicNumbers.LEGACY_LAST_POS) {
+            return CraftMagicNumbers.LEGACY_FIRST_POS + ord - CraftMagicNumbers.LEGACY_LAST_POS - 1;
+        }
+        else {
+            return ord;
+        }
     }
 }

--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/util/CraftMagicNumbers.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/util/CraftMagicNumbers.java
@@ -89,6 +89,10 @@ public final class CraftMagicNumbers implements UnsafeValues {
     public static final Map<Material, Block> MATERIAL_BLOCK = new HashMap<>();
     private static final Map<Material, net.minecraft.fluid.Fluid> MATERIAL_FLUID = new HashMap<>();
 
+    // Mohist: Legacy Material first/last ordinals
+    public static final int LEGACY_FIRST_POS;
+    public static final int LEGACY_LAST_POS;
+
     static {
         for (Block block : Registry.BLOCK) {
             BLOCK_MATERIAL.put(block, Material.getMaterial(Registry.BLOCK.getKey(block).getPath().toUpperCase(Locale.ROOT)));
@@ -102,8 +106,15 @@ public final class CraftMagicNumbers implements UnsafeValues {
             FLUID_MATERIAL.put(fluid, org.bukkit.Registry.FLUID.get(CraftNamespacedKey.fromMinecraft(Registry.FLUID.getKey(fluid))));
         }
 
+        Integer legacyFirstPos = null;
+        Integer legacyLastPos = null;
         for (Material material : Material.values()) {
             if (material.isLegacy()) {
+                int ord = material.ordinal();
+                if (legacyFirstPos == null) {
+                    legacyFirstPos = ord;
+                }
+                legacyLastPos = ord;
                 continue;
             }
 
@@ -118,6 +129,9 @@ public final class CraftMagicNumbers implements UnsafeValues {
                 MATERIAL_FLUID.put(material, fluid);
             });
         }
+
+        LEGACY_FIRST_POS = legacyFirstPos;
+        LEGACY_LAST_POS = legacyLastPos;
     }
 
     public static Material getMaterial(Block block) {


### PR DESCRIPTION
So there is that remapping utility ("Legacy Support" / CraftLegacy.java), which overrides calls to *Material.values()* and *material.ordinal()* through ASM.
The problem is that array is copied prematurely, leaving Forge materials behind, which indirectly leads to a load of unobvious bugs (I, personally, bumped into ArrayIndexOutOfBounds with switch operator on Materials).

So what happened before:
- With "api-version" defined: modern materials without forge
- No "api-version" in plugin.yml: legacy materials + forge

Now that will be as follows:
- With "api-version" defined: modern materials + forge
- No "api-version" in plugin.yml: legacy materials + forge