### PR TITLE
Do not attempt to call BlockPlaceEvent if playerentity is null

### DIFF
--- a/patches/minecraft/net/minecraft/item/BlockItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BlockItem.java.patch
@@ -41,7 +41,7 @@
                    this.func_195943_a(blockpos, world, playerentity, itemstack, blockstate1);
                    block.func_180633_a(world, blockpos, blockstate1, playerentity, itemstack);
 +                  // CraftBukkit start
-+                  if (cbblockstate != null) {
++                  if (cbblockstate != null && playerentity != null) {
 +                     org.bukkit.event.block.BlockPlaceEvent placeEvent = org.bukkit.craftbukkit.v1_16_R3.event.CraftEventFactory.callBlockPlaceEvent((ServerWorld) world, playerentity, blockitemusecontext.func_221531_n(), cbblockstate, blockpos.func_177958_n(), blockpos.func_177956_o(), blockpos.func_177952_p());
 +                     if (placeEvent != null && (placeEvent.isCancelled() || !placeEvent.canBuild())) {
 +                        cbblockstate.update(true, false);


### PR DESCRIPTION
Fixes #839. DirectionalPlaceContext objects have a null `player` field, however CraftBukkit's `callBlockPlaceEvent` method does not seem to consider this.