### PR TITLE
Fix startup from classpath on Java 9+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -735,6 +735,7 @@ project(':forge') {
             MANIFESTS.each{ pkg, values ->
                 if (pkg == '/') {
                     manifest.attributes(values += [
+                        'Premain-Class': 'com.mohistmc.util.JarLoader',
                         'Launcher-Agent-Class': 'com.mohistmc.util.JarLoader',
                         'Main-Class': 'net.minecraftforge.server.ServerMain',
                         'Class-Path': classpath.toString(),
@@ -805,6 +806,7 @@ project(':forge') {
             MANIFESTS.each{ pkg, values ->
                 if (pkg == '/') {
                     manifest.attributes(values += [
+                            'Premain-Class': 'com.mohistmc.util.JarLoader',
                             'Launcher-Agent-Class': 'com.mohistmc.util.JarLoader',
                             'Main-Class': 'net.minecraftforge.server.ServerMain',
                             'Class-Path': classpath.toString(),

--- a/src/fmllauncher/java/com/mohistmc/util/JarLoader.java
+++ b/src/fmllauncher/java/com/mohistmc/util/JarLoader.java
@@ -19,6 +19,12 @@ public class JarLoader {
         JarLoader.inst = inst;
     }
 
+    // Don't forget to specify -javaagent:<mohist jar> on Java 9+,
+    // if you load main Mohist jar from -cp rather than direct -jar
+    public static void premain(String agentArgs, Instrumentation inst) {
+        JarLoader.inst = inst;
+    }
+
     public void loadJar(File path) throws Exception {
         ClassLoader cl = ClassLoader.getSystemClassLoader();
         if (!path.getName().equals("minecraft_server.1.16.5.jar")) {


### PR DESCRIPTION
If you specify -cp with Mohist jar on Java 9+ and then invoke main class (net.minecraftforge.server.ServerMain), startup will fail, because instrumentation is null. This PR fixes that.