### PR TITLE
Include both Commons-lang 2.6 and 3.3.2 into Mohist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ buildscript {
             name 'spigot'
             url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
         }
+       	maven {
+	        name 'Commons-lang3'
+		    url 'https://mvnrepository.com/artifact/'
+	    }
 
         mavenCentral()
     }
@@ -99,6 +103,7 @@ dependencies {
     libraries 'lzma:lzma:0.0.1'
     libraries 'org.yaml:snakeyaml:1.9'
     libraries 'commons-lang:commons-lang:2.6'
+    libraries group: 'org.apache.commons', name: 'commons-lang3', version: '3.3.2'
     libraries 'org.avaje:ebean:2.7.3'
     libraries 'jline:jline:2.6'
     libraries 'net.md-5:SpecialSource:1.7.4'

--- a/src/main/resources/mohist_libraries.txt
+++ b/src/main/resources/mohist_libraries.txt
@@ -44,3 +44,4 @@ libraries/org/xerial/sqlite-jdbc/3.7.2/sqlite-jdbc-3.7.2.jar|1a6796add6898d6a179
 libraries/org/yaml/snakeyaml/1.9/snakeyaml-1.9.jar|aee7d6eb28be4b13a207cb6dc565a7db
 libraries/pw/prok/KImagine/0.2.0/KImagine-0.2.0.jar|f4314231d8ae2f5760edab74454f7b48
 libraries/net/minecraft/server/1.7.10/server-1.7.10.jar|3e8912b293b52bd54f879919bd6e4e44
+libraries/org/apache/commons/commons-lang3/3.3.2/commons-lang3-3.3.2.jar|3128bf75a2549ebe38663401191bacab


### PR DESCRIPTION
Fixes Compatibility with the Pack Gregtech: New Horizons in future but not breaks other packs.
Both can co-exist since they have different classpaths.