### PR TITLE
Fix permission plugins after respawn

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/management/PlayerList.java
 +++ b/net/minecraft/server/management/PlayerList.java
-@@ -1,23 +1,33 @@
+@@ -1,23 +1,35 @@
  package net.minecraft.server.management;
  
 +import com.google.common.base.Predicate;
@@ -13,6 +13,8 @@
  import com.mojang.serialization.Dynamic;
  import io.netty.buffer.Unpooled;
  import java.io.File;
++import java.lang.reflect.Field;
++import java.lang.reflect.Modifier;
 +import java.net.InetAddress;
 +import java.net.InetSocketAddress;
  import java.net.SocketAddress;
@@ -34,7 +36,7 @@
  import net.minecraft.entity.Entity;
  import net.minecraft.entity.EntityType;
  import net.minecraft.entity.player.PlayerEntity;
-@@ -27,10 +37,12 @@
+@@ -27,10 +39,12 @@
  import net.minecraft.network.IPacket;
  import net.minecraft.network.NetworkManager;
  import net.minecraft.network.PacketBuffer;
@@ -47,7 +49,7 @@
  import net.minecraft.network.play.server.SEntityStatusPacket;
  import net.minecraft.network.play.server.SHeldItemChangePacket;
  import net.minecraft.network.play.server.SJoinGamePacket;
-@@ -38,6 +50,7 @@
+@@ -38,6 +52,7 @@
  import net.minecraft.network.play.server.SPlaySoundEffectPacket;
  import net.minecraft.network.play.server.SPlayerAbilitiesPacket;
  import net.minecraft.network.play.server.SPlayerListItemPacket;
@@ -55,7 +57,7 @@
  import net.minecraft.network.play.server.SRespawnPacket;
  import net.minecraft.network.play.server.SServerDifficultyPacket;
  import net.minecraft.network.play.server.SSetExperiencePacket;
-@@ -54,6 +67,7 @@
+@@ -54,6 +69,7 @@
  import net.minecraft.scoreboard.ServerScoreboard;
  import net.minecraft.scoreboard.Team;
  import net.minecraft.server.MinecraftServer;
@@ -63,7 +65,7 @@
  import net.minecraft.stats.ServerStatisticsManager;
  import net.minecraft.stats.Stats;
  import net.minecraft.tags.BlockTags;
-@@ -85,6 +99,19 @@
+@@ -85,6 +101,20 @@
  import net.minecraftforge.api.distmarker.OnlyIn;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
@@ -72,6 +74,7 @@
 +import org.bukkit.craftbukkit.v1_16_R3.CraftServer;
 +import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
 +import org.bukkit.craftbukkit.v1_16_R3.command.ColouredConsoleSender;
++import org.bukkit.craftbukkit.v1_16_R3.entity.CraftHumanEntity;
 +import org.bukkit.craftbukkit.v1_16_R3.util.CraftChatMessage;
 +import org.bukkit.entity.Player;
 +import org.bukkit.event.player.PlayerChangedWorldEvent;
@@ -83,7 +86,7 @@
  
  public abstract class PlayerList {
     public static final File field_152613_a = new File("banned-players.json");
-@@ -94,7 +121,7 @@
+@@ -94,7 +124,7 @@
     private static final Logger field_148546_d = LogManager.getLogger();
     private static final SimpleDateFormat field_72403_e = new SimpleDateFormat("yyyy-MM-dd 'at' HH:mm:ss z");
     private final MinecraftServer field_72400_f;
@@ -92,7 +95,7 @@
     private final Map<UUID, ServerPlayerEntity> field_177454_f = Maps.newHashMap();
     private final BanList field_72401_g = new BanList(field_152613_a);
     private final IPBanList field_72413_h = new IPBanList(field_152614_b);
-@@ -102,7 +129,7 @@
+@@ -102,7 +132,7 @@
     private final WhiteList field_72411_j = new WhiteList(field_152616_d);
     private final Map<UUID, ServerStatisticsManager> field_148547_k = Maps.newHashMap();
     private final Map<UUID, PlayerAdvancements> field_192055_p = Maps.newHashMap();
@@ -101,7 +104,7 @@
     private boolean field_72409_l;
     private final DynamicRegistries.Impl field_232639_s_;
     protected final int field_72405_c;
-@@ -110,8 +137,30 @@
+@@ -110,8 +140,30 @@
     private GameType field_72410_m;
     private boolean field_72407_n;
     private int field_72408_o;
@@ -132,7 +135,7 @@
        this.field_72400_f = p_i231425_1_;
        this.field_232639_s_ = p_i231425_2_;
        this.field_72405_c = p_i231425_4_;
-@@ -125,11 +174,19 @@
+@@ -125,11 +177,19 @@
        String s = gameprofile1 == null ? gameprofile.getName() : gameprofile1.getName();
        playerprofilecache.func_152649_a(gameprofile);
        CompoundNBT compoundnbt = this.func_72380_a(p_72355_2_);
@@ -153,7 +156,7 @@
           serverworld1 = this.field_72400_f.func_241755_D_();
        } else {
           serverworld1 = serverworld;
-@@ -142,20 +199,36 @@
+@@ -142,20 +202,36 @@
           s1 = p_72355_1_.func_74430_c().toString();
        }
  
@@ -189,11 +192,11 @@
        serverplaynethandler.func_147359_a(new STagsListPacket(this.field_72400_f.func_244266_aF()));
 +      serverplaynethandler.func_147359_a(new SEntityStatusPacket(p_72355_2_, (byte) (serverworld1.func_82736_K().func_223586_b(GameRules.field_223612_o) ? 22 : 23))); // Paper - fix this rule not being initialized on the client
 +      net.minecraftforge.fml.network.NetworkHooks.syncCustomTagTypes(p_72355_2_, this.field_72400_f.func_244266_aF());
-+   
++
        this.func_187243_f(p_72355_2_);
        p_72355_2_.func_147099_x().func_150877_d();
        p_72355_2_.func_192037_E().func_192826_c(p_72355_2_);
-@@ -167,19 +240,55 @@
+@@ -167,19 +243,55 @@
        } else {
           iformattabletextcomponent = new TranslationTextComponent("multiplayer.player.joined.renamed", p_72355_2_.func_145748_c_(), s);
        }
@@ -254,7 +257,7 @@
        this.func_72354_b(p_72355_2_, serverworld1);
        if (!this.field_72400_f.func_147133_T().isEmpty()) {
           p_72355_2_.func_175397_a(this.field_72400_f.func_147133_T(), this.field_72400_f.func_175581_ab());
-@@ -191,8 +300,9 @@
+@@ -191,8 +303,9 @@
  
        if (compoundnbt != null && compoundnbt.func_150297_b("RootVehicle", 10)) {
           CompoundNBT compoundnbt1 = compoundnbt.func_74775_l("RootVehicle");
@@ -265,7 +268,7 @@
           });
           if (entity1 != null) {
              UUID uuid;
-@@ -214,7 +324,7 @@
+@@ -214,7 +327,7 @@
              }
  
              if (!p_72355_2_.func_184218_aH()) {
@@ -274,7 +277,7 @@
                 serverworld1.func_217467_h(entity1);
  
                 for(Entity entity2 : entity1.func_184182_bu()) {
-@@ -225,9 +335,10 @@
+@@ -225,9 +338,10 @@
        }
  
        p_72355_2_.func_71116_b();
@@ -286,7 +289,7 @@
        Set<ScoreObjective> set = Sets.newHashSet();
  
        for(ScorePlayerTeam scoreplayerteam : p_96456_1_.func_96525_g()) {
-@@ -248,6 +359,7 @@
+@@ -248,6 +362,7 @@
     }
  
     public void func_212504_a(ServerWorld p_212504_1_) {
@@ -294,7 +297,7 @@
        p_212504_1_.func_175723_af().func_177737_a(new IBorderListener() {
           public void func_177694_a(WorldBorder p_177694_1_, double p_177694_2_) {
              PlayerList.this.func_148540_a(new SWorldBorderPacket(p_177694_1_, SWorldBorderPacket.Action.SET_SIZE));
-@@ -284,7 +396,8 @@
+@@ -284,7 +399,8 @@
        if (p_72380_1_.func_200200_C_().getString().equals(this.field_72400_f.func_71214_G()) && compoundnbt != null) {
           compoundnbt1 = compoundnbt;
           p_72380_1_.func_70020_e(compoundnbt);
@@ -304,7 +307,7 @@
        } else {
           compoundnbt1 = this.field_72412_k.func_237336_b_(p_72380_1_);
        }
-@@ -293,6 +406,8 @@
+@@ -293,6 +409,8 @@
     }
  
     protected void func_72391_b(ServerPlayerEntity p_72391_1_) {
@@ -313,7 +316,7 @@
        this.field_72412_k.func_237335_a_(p_72391_1_);
        ServerStatisticsManager serverstatisticsmanager = this.field_148547_k.get(p_72391_1_.func_110124_au());
        if (serverstatisticsmanager != null) {
-@@ -306,14 +421,32 @@
+@@ -306,14 +424,32 @@
  
     }
  
@@ -347,7 +350,7 @@
              p_72367_1_.func_184210_p();
              serverworld.func_217467_h(entity);
              entity.field_70128_L = true;
-@@ -330,7 +463,8 @@
+@@ -330,7 +466,8 @@
        p_72367_1_.func_213319_R();
        serverworld.func_217434_e(p_72367_1_);
        p_72367_1_.func_192039_O().func_192745_a();
@@ -357,7 +360,7 @@
        this.field_72400_f.func_201300_aS().func_201382_b(p_72367_1_);
        UUID uuid = p_72367_1_.func_110124_au();
        ServerPlayerEntity serverplayerentity = this.field_177454_f.get(uuid);
-@@ -340,32 +474,74 @@
+@@ -340,32 +477,74 @@
           this.field_192055_p.remove(uuid);
        }
  
@@ -448,7 +451,7 @@
     }
  
     public ServerPlayerEntity func_148545_a(GameProfile p_148545_1_) {
-@@ -400,8 +576,15 @@
+@@ -400,8 +579,18 @@
     }
  
     public ServerPlayerEntity func_232644_a_(ServerPlayerEntity p_232644_1_, boolean p_232644_2_) {
@@ -458,6 +461,9 @@
 +      return this.moveToWorld(p_232644_1_, this.field_72400_f.func_71218_a(p_232644_1_.func_241141_L_()), p_232644_2_, null, true);
 +   }
 +
++   // Mohist
++   private static Field permField, modifiersField;
++
 +   public ServerPlayerEntity moveToWorld(ServerPlayerEntity p_232644_1_, ServerWorld serverWorld, boolean p_232644_2_, Location location, boolean avoidSuffocation) {
 +      p_232644_1_.func_184210_p(); // CraftBukkit
 +      this.removePlayer(p_232644_1_);
@@ -466,7 +472,7 @@
        BlockPos blockpos = p_232644_1_.func_241140_K_();
        float f = p_232644_1_.func_242109_L();
        boolean flag = p_232644_1_.func_241142_M_();
-@@ -422,8 +605,13 @@
+@@ -422,8 +611,13 @@
        }
  
        ServerPlayerEntity serverplayerentity = new ServerPlayerEntity(this.field_72400_f, serverworld1, p_232644_1_.func_146103_bH(), playerinteractionmanager);
@@ -480,7 +486,7 @@
        serverplayerentity.func_145769_d(p_232644_1_.func_145782_y());
        serverplayerentity.func_184819_a(p_232644_1_.func_184591_cq());
  
-@@ -431,48 +619,111 @@
+@@ -431,48 +625,128 @@
           serverplayerentity.func_184211_a(s);
        }
  
@@ -534,6 +540,23 @@
 +            location = new Location(serverworld1.getCBWorld(), (double) ((float) blockpos.func_177958_n() + 0.5F), (double) ((float) blockpos.func_177956_o() + 0.1F), (double) ((float) blockpos.func_177952_p() + 0.5F));
 +         }
 +         Player respawnPlayer = cserver.getPlayer(serverplayerentity);
++         // Mohist: Transfer PermissibleBase from old player instance
++         try {
++             if (permField == null) {
++                 permField = CraftHumanEntity.class.getDeclaredField("perm");
++                 permField.setAccessible(true);
++                 if (modifiersField == null) {
++                     modifiersField = Field.class.getDeclaredField("modifiers");
++                     modifiersField.setAccessible(true);
++                 }
++                 modifiersField.set(permField, permField.getModifiers() & ~Modifier.FINAL);
++             }
++             permField.set(respawnPlayer, permField.get(p_232644_1_.getBukkitEntity()));
++         } catch (Exception ex) {
++             field_148546_d.warn("Mohist was unable to transfer PermissibleBase from old player instance!");
++             field_148546_d.warn("Expect problems related to permission checking :(");
++             ex.printStackTrace();
++         }
 +         PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(respawnPlayer, location, isBedSpawn && !flag2, flag2);
 +         cserver.getPluginManager().callEvent(respawnEvent);
 +         // Spigot Start
@@ -617,7 +640,7 @@
        return serverplayerentity;
     }
  
-@@ -484,12 +735,40 @@
+@@ -484,12 +758,40 @@
  
     public void func_72374_b() {
        if (++this.field_72408_o > 600) {
@@ -659,7 +682,7 @@
     public void func_148540_a(IPacket<?> p_148540_1_) {
        for(int i = 0; i < this.field_72404_b.size(); ++i) {
           (this.field_72404_b.get(i)).field_71135_a.func_147359_a(p_148540_1_);
-@@ -585,6 +864,7 @@
+@@ -585,6 +887,7 @@
           p_187245_1_.field_71135_a.func_147359_a(new SEntityStatusPacket(p_187245_1_, b0));
        }
  
@@ -667,7 +690,7 @@
        this.field_72400_f.func_195571_aL().func_197051_a(p_187245_1_);
     }
  
-@@ -598,18 +878,19 @@
+@@ -598,18 +901,19 @@
  
     @Nullable
     public ServerPlayerEntity func_152612_a(String p_152612_1_) {
@@ -694,7 +717,7 @@
           if (serverplayerentity != p_148543_1_ && serverplayerentity.field_70170_p.func_234923_W_() == p_148543_10_) {
              double d0 = p_148543_2_ - serverplayerentity.func_226277_ct_();
              double d1 = p_148543_4_ - serverplayerentity.func_226278_cu_();
-@@ -649,22 +930,32 @@
+@@ -649,22 +953,32 @@
     }
  
     public void func_72354_b(ServerPlayerEntity p_72354_1_, ServerWorld p_72354_2_) {
@@ -729,7 +752,7 @@
     }
  
     public int func_72394_k() {
-@@ -719,7 +1010,7 @@
+@@ -719,7 +1033,7 @@
           p_72381_1_.field_71134_c.func_241820_a(this.field_72410_m, GameType.NOT_SET);
        }
  
@@ -738,7 +761,7 @@
     }
  
     @OnlyIn(Dist.CLIENT)
-@@ -728,25 +1019,44 @@
+@@ -728,25 +1042,44 @@
     }
  
     public void func_72392_r() {
@@ -788,7 +811,7 @@
              if (file3.exists() && file3.isFile()) {
                 file3.renameTo(file2);
              }
-@@ -769,6 +1079,8 @@
+@@ -769,6 +1102,8 @@
           this.field_192055_p.put(uuid, playeradvancements);
        }
  
@@ -797,7 +820,7 @@
        playeradvancements.func_192739_a(p_192054_1_);
        return playeradvancements;
     }
-@@ -786,7 +1098,7 @@
+@@ -786,7 +1121,7 @@
     }
  
     public List<ServerPlayerEntity> func_181057_v() {
@@ -806,7 +829,7 @@
     }
  
     @Nullable
-@@ -804,6 +1116,7 @@
+@@ -804,6 +1139,7 @@
        }
  
        this.func_148540_a(new STagsListPacket(this.field_72400_f.func_244266_aF()));
@@ -814,7 +837,7 @@
        SUpdateRecipesPacket supdaterecipespacket = new SUpdateRecipesPacket(this.field_72400_f.func_199529_aN().func_199510_b());
  
        for(ServerPlayerEntity serverplayerentity : this.field_72404_b) {
-@@ -816,4 +1129,12 @@
+@@ -816,4 +1152,12 @@
     public boolean func_206257_x() {
        return this.field_72407_n;
     }


### PR DESCRIPTION
Some permission-related plugins ([LuckPerms](https://github.com/lucko/LuckPerms), for example) rely on CraftHumanEntity's PermissibleBase replacement to provide their own permission checks.
However, Forge recreates the player instance on respawn, thus resetting the PermissibleBase until affected player rejoins the server.
This is now fixed by transferring PermissibleBase from old instance into the new one.