### PR TITLE
Prevent out of bounds in ChunkHolder

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ChunkHolder.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkHolder.java.patch
@@ -44,7 +44,16 @@
     public CompletableFuture<Either<IChunk, ChunkHolder.IChunkLoadingError>> func_219301_a(ChunkStatus p_219301_1_) {
        CompletableFuture<Either<IChunk, ChunkHolder.IChunkLoadingError>> completablefuture = this.field_219312_g.get(p_219301_1_.func_222584_c());
        return completablefuture == null ? field_219307_b : completablefuture;
-@@ -204,7 +216,7 @@
+@@ -139,6 +151,8 @@
+       Chunk chunk = this.func_219298_c();
+       if (chunk != null) {
+          byte b0 = (byte)SectionPos.func_218159_a(p_244386_1_.func_177956_o());
++         // Mohist: Prevent out of bounds
++         if (b0 < 0 || b0 > 15) return;
+          if (this.field_244383_q[b0] == null) {
+             this.field_244382_p = true;
+             this.field_244383_q[b0] = new ShortArraySet();
+@@ -204,7 +218,7 @@
     }
  
     private void func_244385_a(World p_244385_1_, BlockPos p_244385_2_, BlockState p_244385_3_) {
@@ -53,7 +62,7 @@
           this.func_219305_a(p_244385_1_, p_244385_2_);
        }
  
-@@ -289,6 +301,31 @@
+@@ -289,6 +303,31 @@
        boolean flag1 = this.field_219317_l <= ChunkManager.field_219249_a;
        ChunkHolder.LocationType chunkholder$locationtype = func_219286_c(this.field_219316_k);
        ChunkHolder.LocationType chunkholder$locationtype1 = func_219286_c(this.field_219317_l);
@@ -85,7 +94,7 @@
        if (flag) {
           Either<IChunk, ChunkHolder.IChunkLoadingError> either = Either.right(new ChunkHolder.IChunkLoadingError() {
              public String toString() {
-@@ -352,6 +389,24 @@
+@@ -352,6 +391,24 @@
  
        this.field_219327_v.func_219066_a(this.field_219319_n, this::func_219281_j, this.field_219317_l, this::func_219275_d);
        this.field_219316_k = this.field_219317_l;


### PR DESCRIPTION
For unknown exact reason (mods/vanilla behaviour?) sometimes b0 in this particular function equals -1, which results in out of bounds and server crash.
This PR prevents OOB and the following crash.