### PR TITLE
Duplicate Spawns + Containers

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/container/Container.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/Container.java.patch
@@ -39,7 +39,7 @@
     private final Set<PlayerEntity> field_75148_f = Sets.newHashSet();
  
 +   // CraftBukkit start
-+   public boolean checkReachable;
++   public boolean checkReachable = true;
 +   private ITextComponent title;
 +   // Mohist start
 +   public InventoryView bukkitView = null;

--- a/patches/minecraft/net/minecraft/inventory/container/Container.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/Container.java.patch
@@ -14,11 +14,12 @@
  import net.minecraft.block.Block;
  import net.minecraft.crash.CrashReport;
  import net.minecraft.crash.CrashReportCategory;
-@@ -21,13 +24,17 @@
+@@ -21,13 +24,18 @@
  import net.minecraft.util.NonNullList;
  import net.minecraft.util.math.MathHelper;
  import net.minecraft.util.registry.Registry;
 +import net.minecraft.util.text.ITextComponent;
++import net.minecraft.util.text.StringTextComponent;
  import net.minecraft.world.World;
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
@@ -34,7 +35,7 @@
     private final List<IntReferenceHolder> field_216964_d = Lists.newArrayList();
     @Nullable
     private final ContainerType<?> field_216965_e;
-@@ -40,6 +47,62 @@
+@@ -40,6 +48,64 @@
     private final List<IContainerListener> field_75149_d = Lists.newArrayList();
     private final Set<PlayerEntity> field_75148_f = Sets.newHashSet();
  
@@ -84,12 +85,14 @@
 +   }
 +
 +   public final ITextComponent getTitle() {
-+      Preconditions.checkState(this.title != null, (Object) "Title not set");
++      // Mohist: null title -> empty title
++      if (this.title == null) {
++         this.title = new StringTextComponent("");
++      }
 +      return this.title;
 +   }
 +
 +   public final void setTitle(final ITextComponent title) {
-+      Preconditions.checkState(this.title == null, (Object) "Title already set");
 +      this.title = title;
 +   }
 +   // CraftBukkit end
@@ -97,7 +100,7 @@
     protected Container(@Nullable ContainerType<?> p_i50105_1_, int p_i50105_2_) {
        this.field_216965_e = p_i50105_1_;
        this.field_75152_c = p_i50105_2_;
-@@ -120,9 +183,11 @@
+@@ -120,9 +186,11 @@
           ItemStack itemstack = this.field_75151_b.get(i).func_75211_c();
           ItemStack itemstack1 = this.field_75153_a.get(i);
           if (!ItemStack.func_77989_b(itemstack1, itemstack)) {
@@ -109,7 +112,7 @@
              for(IContainerListener icontainerlistener : this.field_75149_d) {
                 icontainerlistener.func_71111_a(this, i, itemstack2);
              }
-@@ -500,14 +565,15 @@
+@@ -500,14 +568,15 @@
              ItemStack itemstack = slot.func_75211_c();
              if (!itemstack.func_190926_b() && func_195929_a(p_75135_1_, itemstack)) {
                 int j = itemstack.func_190916_E() + p_75135_1_.func_190916_E();
@@ -129,7 +132,7 @@
                    slot.func_75218_e();
                    flag = true;
                 }
-@@ -608,7 +674,7 @@
+@@ -608,7 +677,7 @@
           p_94525_2_.func_190920_e(1);
           break;
        case 2:

--- a/patches/minecraft/net/minecraft/util/IWorldPosCallable.java.patch
+++ b/patches/minecraft/net/minecraft/util/IWorldPosCallable.java.patch
@@ -1,16 +1,32 @@
 --- a/net/minecraft/util/IWorldPosCallable.java
 +++ b/net/minecraft/util/IWorldPosCallable.java
-@@ -7,6 +7,19 @@
+@@ -3,10 +3,35 @@
+ import java.util.Optional;
+ import java.util.function.BiConsumer;
+ import java.util.function.BiFunction;
++
++import org.apache.logging.log4j.LogManager;
++
++import net.minecraft.server.MinecraftServer;
+ import net.minecraft.util.math.BlockPos;
  import net.minecraft.world.World;
  
  public interface IWorldPosCallable {
 +
 +   // CraftBukkit start
 +   default World getWorld() {
-+      throw new UnsupportedOperationException("Not supported yet.");
++      LogManager.getLogger().warn("Mohist detected a call to getWorld() in dummy IWorldPosCallable.");
++      LogManager.getLogger().warn("This shouldn't be happening! See/Report stacktrace below:");
++      Thread.dumpStack();
++      // Mohist: Return first available world instead of exception
++      return MinecraftServer.getServer().func_212370_w().iterator().next();
 +   }
 +   default BlockPos getPosition() {
-+      throw new UnsupportedOperationException("Not supported yet.");
++      LogManager.getLogger().warn("Mohist detected a call to getPosition() in dummy IWorldPosCallable.");
++      LogManager.getLogger().warn("This shouldn't be happening! See/Report stacktrace below:");
++      Thread.dumpStack();
++      // Mohist: Return dummy blockpos instead of exception
++      return new BlockPos(0, 0, 0);
 +   }
 +   default org.bukkit.Location getLocation() {
 +      return new org.bukkit.Location(getWorld().getCBWorld(), getPosition().func_177958_n(), getPosition().func_177956_o(), getPosition().func_177952_p());
@@ -20,7 +36,7 @@
     IWorldPosCallable field_221489_a = new IWorldPosCallable() {
        public <T> Optional<T> func_221484_a(BiFunction<World, BlockPos, T> p_221484_1_) {
           return Optional.empty();
-@@ -15,6 +28,18 @@
+@@ -15,6 +40,18 @@
  
     static IWorldPosCallable func_221488_a(final World p_221488_0_, final BlockPos p_221488_1_) {
        return new IWorldPosCallable() {

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -373,26 +373,9 @@
        if (func_189509_E(p_180495_1_)) {
           return Blocks.field_201940_ji.func_176223_P();
        } else {
-@@ -390,11 +575,29 @@
-       return f * ((float)Math.PI * 2F);
+@@ -391,10 +576,12 @@
     }
  
-+   //Mohist start - fix unknown entity class
-+   public boolean addEntity(Entity entity, CreatureSpawnEvent.SpawnReason spawnReason) {
-+      if (getCBWorld().getHandle() != (Object) this) {
-+         return ((World) getCBWorld().getHandle()).addEntity(entity, spawnReason);
-+      } else {
-+         this.pushAddEntityReason(spawnReason);
-+         return this.func_217376_c(entity);
-+      }
-+   }
-+
-+   public void pushAddEntityReason(CreatureSpawnEvent.SpawnReason reason) {
-+      if (getCBWorld().getHandle() != (Object) this) {
-+         ((World) getCBWorld().getHandle()).pushAddEntityReason(reason);
-+      }
-+   }
-+
     public boolean func_175700_a(TileEntity p_175700_1_) {
 +      if (p_175700_1_.func_145831_w() != this) p_175700_1_.func_226984_a_(this, p_175700_1_.func_174877_v()); // Forge - set the world early as vanilla doesn't set it until next tick
        if (this.field_147481_N) {
@@ -403,7 +386,7 @@
        }
  
        boolean flag = this.field_147482_g.add(p_175700_1_);
-@@ -402,6 +605,8 @@
+@@ -402,6 +589,8 @@
           this.field_175730_i.add(p_175700_1_);
        }
  
@@ -412,7 +395,7 @@
        if (this.field_72995_K) {
           BlockPos blockpos = p_175700_1_.func_174877_v();
           BlockState blockstate = this.func_180495_p(blockpos);
-@@ -413,6 +618,7 @@
+@@ -413,6 +602,7 @@
  
     public void func_147448_a(Collection<TileEntity> p_147448_1_) {
        if (this.field_147481_N) {
@@ -420,7 +403,7 @@
           this.field_147484_a.addAll(p_147448_1_);
        } else {
           for(TileEntity tileentity : p_147448_1_) {
-@@ -425,24 +631,43 @@
+@@ -425,24 +615,43 @@
     public void func_217391_K() {
        IProfiler iprofiler = this.func_217381_Z();
        iprofiler.func_76320_a("blockEntities");
@@ -472,7 +455,7 @@
                    if (tileentity.func_200662_C().func_223045_a(this.func_180495_p(blockpos).func_177230_c())) {
                       ((ITickableTileEntity)tileentity).func_73660_a();
                    } else {
-@@ -454,35 +679,60 @@
+@@ -454,35 +663,60 @@
                    CrashReport crashreport = CrashReport.func_85055_a(throwable, "Ticking block entity");
                    CrashReportCategory crashreportcategory = crashreport.func_85058_a("Block entity being ticked");
                    tileentity.func_145828_a(crashreportcategory);
@@ -537,7 +520,7 @@
                 }
              }
           }
-@@ -490,17 +740,24 @@
+@@ -490,17 +724,24 @@
           this.field_147484_a.clear();
        }
  
@@ -562,7 +545,7 @@
        }
     }
  
-@@ -514,6 +771,7 @@
+@@ -514,6 +755,7 @@
  
     public Explosion func_230546_a_(@Nullable Entity p_230546_1_, @Nullable DamageSource p_230546_2_, @Nullable ExplosionContext p_230546_3_, double p_230546_4_, double p_230546_6_, double p_230546_8_, float p_230546_10_, boolean p_230546_11_, Explosion.Mode p_230546_12_) {
        Explosion explosion = new Explosion(this, p_230546_1_, p_230546_2_, p_230546_3_, p_230546_4_, p_230546_6_, p_230546_8_, p_230546_10_, p_230546_11_, p_230546_12_);
@@ -570,7 +553,7 @@
        explosion.func_77278_a();
        explosion.func_77279_a(true);
        return explosion;
-@@ -525,22 +783,34 @@
+@@ -525,22 +767,34 @@
  
     @Nullable
     public TileEntity func_175625_s(BlockPos p_175625_1_) {
@@ -609,7 +592,7 @@
           }
  
           return tileentity;
-@@ -561,7 +831,15 @@
+@@ -561,7 +815,15 @@
  
     public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_) {
        if (!func_189509_E(p_175690_1_)) {
@@ -625,7 +608,7 @@
              if (this.field_147481_N) {
                 p_175690_2_.func_226984_a_(this, p_175690_1_);
                 Iterator<TileEntity> iterator = this.field_147484_a.iterator();
-@@ -576,7 +854,8 @@
+@@ -576,7 +838,8 @@
  
                 this.field_147484_a.add(p_175690_2_);
              } else {
@@ -635,7 +618,7 @@
                 this.func_175700_a(p_175690_2_);
              }
           }
-@@ -585,10 +864,12 @@
+@@ -585,10 +848,12 @@
     }
  
     public void func_175713_t(BlockPos p_175713_1_) {
@@ -649,7 +632,7 @@
        } else {
           if (tileentity != null) {
              this.field_147484_a.remove(tileentity);
-@@ -598,7 +879,7 @@
+@@ -598,7 +863,7 @@
  
           this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
        }
@@ -658,7 +641,7 @@
     }
  
     public boolean func_195588_v(BlockPos p_195588_1_) {
-@@ -651,10 +932,10 @@
+@@ -651,10 +916,10 @@
     public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate<? super Entity> p_175674_3_) {
        this.func_217381_Z().func_230035_c_("getEntities");
        List<Entity> list = Lists.newArrayList();
@@ -673,7 +656,7 @@
        AbstractChunkProvider abstractchunkprovider = this.func_72863_F();
  
        for(int i1 = i; i1 <= j; ++i1) {
-@@ -671,10 +952,10 @@
+@@ -671,10 +936,10 @@
  
     public <T extends Entity> List<T> func_217394_a(@Nullable EntityType<T> p_217394_1_, AxisAlignedBB p_217394_2_, Predicate<? super T> p_217394_3_) {
        this.func_217381_Z().func_230035_c_("getEntities");
@@ -688,7 +671,7 @@
        List<T> list = Lists.newArrayList();
  
        for(int i1 = i; i1 < j; ++i1) {
-@@ -691,10 +972,10 @@
+@@ -691,10 +956,10 @@
  
     public <T extends Entity> List<T> func_175647_a(Class<? extends T> p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate<? super T> p_175647_3_) {
        this.func_217381_Z().func_230035_c_("getEntities");
@@ -703,7 +686,7 @@
        List<T> list = Lists.newArrayList();
        AbstractChunkProvider abstractchunkprovider = this.func_72863_F();
  
-@@ -712,10 +993,10 @@
+@@ -712,10 +977,10 @@
  
     public <T extends Entity> List<T> func_225316_b(Class<? extends T> p_225316_1_, AxisAlignedBB p_225316_2_, @Nullable Predicate<? super T> p_225316_3_) {
        this.func_217381_Z().func_230035_c_("getLoadedEntities");
@@ -718,7 +701,7 @@
        List<T> list = Lists.newArrayList();
        AbstractChunkProvider abstractchunkprovider = this.func_72863_F();
  
-@@ -739,6 +1020,7 @@
+@@ -739,6 +1004,7 @@
           this.func_175726_f(p_175646_1_).func_76630_e();
        }
  
@@ -726,7 +709,7 @@
     }
  
     public int func_181545_F() {
-@@ -783,7 +1065,7 @@
+@@ -783,7 +1049,7 @@
     public int func_175651_c(BlockPos p_175651_1_, Direction p_175651_2_) {
        BlockState blockstate = this.func_180495_p(p_175651_1_);
        int i = blockstate.func_185911_a(this, p_175651_1_, p_175651_2_);
@@ -735,7 +718,7 @@
     }
  
     public boolean func_175640_z(BlockPos p_175640_1_) {
-@@ -938,16 +1220,15 @@
+@@ -938,16 +1204,15 @@
     public abstract Scoreboard func_96441_U();
  
     public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_) {
@@ -756,7 +739,7 @@
                    blockstate.func_215697_a(this, blockpos, p_175666_2_, p_175666_1_, false);
                 }
              }
-@@ -1024,7 +1305,27 @@
+@@ -1024,7 +1289,27 @@
        return this.field_226689_w_;
     }
  

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -456,7 +456,7 @@
           serverchunkprovider.func_217210_a(p_217445_2_);
        }
     }
-@@ -743,13 +833,24 @@
+@@ -743,13 +833,23 @@
     }
  
     public boolean func_217376_c(Entity p_217376_1_) {
@@ -466,8 +466,7 @@
     }
  
 +   public boolean addEntity(Entity entityIn, CreatureSpawnEvent.SpawnReason reason) {
-+      //Mohist - Fix unknown entity class
-+      return this.func_72838_d(entityIn) ? super.addEntity(entityIn, reason) : false;
++      return this.addEntity0(entityIn, reason);
 +   }
 +
     public boolean func_217470_d(Entity p_217470_1_) {
@@ -483,7 +482,7 @@
     public void func_217460_e(Entity p_217460_1_) {
        boolean flag = p_217460_1_.field_98038_p;
        p_217460_1_.field_98038_p = true;
-@@ -777,9 +878,10 @@
+@@ -777,9 +877,10 @@
     }
  
     private void func_217448_f(ServerPlayerEntity p_217448_1_) {
@@ -495,7 +494,7 @@
           entity.func_213319_R();
           this.func_217434_e((ServerPlayerEntity)entity);
        }
-@@ -795,18 +897,24 @@
+@@ -795,18 +896,24 @@
     }
  
     private boolean func_72838_d(Entity p_72838_1_) {
@@ -526,7 +525,7 @@
              return true;
           }
        }
-@@ -816,6 +924,7 @@
+@@ -816,6 +923,7 @@
        if (this.func_217478_l(p_217440_1_)) {
           return false;
        } else {
@@ -534,7 +533,7 @@
           this.func_217465_m(p_217440_1_);
           return true;
        }
-@@ -827,7 +936,7 @@
+@@ -827,7 +935,7 @@
        if (entity == null) {
           return false;
        } else {
@@ -543,7 +542,7 @@
           return true;
        }
     }
-@@ -851,15 +960,30 @@
+@@ -851,15 +959,30 @@
     }
  
     public boolean func_242106_g(Entity p_242106_1_) {
@@ -576,7 +575,7 @@
        this.field_147483_b.addAll(p_217466_1_.func_177434_r().values());
        ClassInheritanceMultiMap<Entity>[] aclassinheritancemultimap = p_217466_1_.func_177429_s();
        int i = aclassinheritancemultimap.length;
-@@ -879,12 +1003,41 @@
+@@ -879,12 +1002,41 @@
  
     }
  
@@ -619,7 +618,7 @@
  
        this.field_175741_N.remove(p_217484_1_.func_110124_au());
        this.func_72863_F().func_217226_b(p_217484_1_);
-@@ -894,10 +1047,19 @@
+@@ -894,10 +1046,19 @@
        }
  
        this.func_96441_U().func_181140_a(p_217484_1_);
@@ -639,7 +638,7 @@
     }
  
     private void func_217465_m(Entity p_217465_1_) {
-@@ -913,20 +1075,31 @@
+@@ -913,20 +1074,31 @@
  
           this.field_175741_N.put(p_217465_1_.func_110124_au(), p_217465_1_);
           this.func_72863_F().func_217230_c(p_217465_1_);
@@ -672,7 +671,7 @@
        }
     }
  
-@@ -939,17 +1112,47 @@
+@@ -939,17 +1111,47 @@
     }
  
     public void func_217434_e(ServerPlayerEntity p_217434_1_) {
@@ -722,7 +721,7 @@
              if (d0 * d0 + d1 * d1 + d2 * d2 < 1024.0D) {
                 serverplayerentity.field_71135_a.func_147359_a(new SAnimateBlockBreakPacket(p_175715_1_, p_175715_2_, p_175715_3_));
              }
-@@ -959,10 +1162,20 @@
+@@ -959,10 +1161,20 @@
     }
  
     public void func_184148_a(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {
@@ -743,7 +742,7 @@
        this.field_73061_a.func_184103_al().func_148543_a(p_217384_1_, p_217384_2_.func_226277_ct_(), p_217384_2_.func_226278_cu_(), p_217384_2_.func_226281_cx_(), p_217384_5_ > 1.0F ? (double)(16.0F * p_217384_5_) : 16.0D, this.func_234923_W_(), new SSpawnMovingSoundEffectPacket(p_217384_3_, p_217384_4_, p_217384_2_, p_217384_5_, p_217384_6_));
     }
  
-@@ -997,9 +1210,17 @@
+@@ -997,9 +1209,17 @@
     }
  
     public Explosion func_230546_a_(@Nullable Entity p_230546_1_, @Nullable DamageSource p_230546_2_, @Nullable ExplosionContext p_230546_3_, double p_230546_4_, double p_230546_6_, double p_230546_8_, float p_230546_10_, boolean p_230546_11_, Explosion.Mode p_230546_12_) {
@@ -764,7 +763,7 @@
        if (p_230546_12_ == Explosion.Mode.NONE) {
           explosion.func_180342_d();
        }
-@@ -1054,12 +1275,19 @@
+@@ -1054,12 +1274,19 @@
     }
  
     public <T extends IParticleData> int func_195598_a(T p_195598_1_, double p_195598_2_, double p_195598_4_, double p_195598_6_, int p_195598_8_, double p_195598_9_, double p_195598_11_, double p_195598_13_, double p_195598_15_) {
@@ -786,7 +785,7 @@
              ++i;
           }
        }
-@@ -1131,7 +1359,13 @@
+@@ -1131,7 +1358,13 @@
     @Nullable
     public MapData func_217406_a(String p_217406_1_) {
        return this.func_73046_m().func_241755_D_().func_217481_x().func_215753_b(() -> {
@@ -801,7 +800,7 @@
        }, p_217406_1_);
     }
  
-@@ -1333,6 +1567,11 @@
+@@ -1333,6 +1566,11 @@
  
     public void func_230547_a_(BlockPos p_230547_1_, Block p_230547_2_) {
        if (!this.func_234925_Z_()) {
@@ -813,7 +812,7 @@
           this.func_195593_d(p_230547_1_, p_230547_2_);
        }
  
-@@ -1399,15 +1638,44 @@
+@@ -1399,15 +1637,44 @@
     }
  
     public static void func_241121_a_(ServerWorld p_241121_0_) {


### PR DESCRIPTION
1. 93858b0989441c812f101444bff108800458bb06 Check container availability by default
Containers are now closing as expected upon going far away or breaking an underlying block.
This did not happen before, and led to possible duping/unintended behavior.
2. 4f22d9d101be07777335af245bd9f02d2381966e Container null title -> empty title for compat
Some mods create their containers with 'null' as title, confusing Bukkit plugins.
Now 'null' title is converted into an empty one.
3. 29e10c30f9153dffeda2f8f07d1ddd2b3a359a44 Avoid rare crash with dummy IWorldPosCallable
This is an interesting one.
Most Vanilla Containers have two constructors, one with IWorldPosCallable provided as argument, and other without.
While the one without an argument isn't used by vanilla MC, it seems that it can be used by mods.
This eventually leads to server crash upon calling getPosition()/getWorld(), since they aren't implemented in dummy version (throws UnsupportedOperationException)
4. 0580237b049602245653d24f93b48107c5c9e2b4  No more duplicate spawns (fixes #937, fixes #956)
@maxanier's train of thought was correct: I've come to the very same conclusion, and this actually worked.
> 
> 
> It seems like the Mohist patches the server world to try to spawn every entity twice:
> 
> https://github.com/Mohist-Community/Mohist/blob/873d95e1889885dcbc6c5e1516c0a8ee36c55344/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch#L470
> 
> I'm sure there is some reason for this, but it definitively is not a viable solution.
> 
>     1. `BeehiveTileEntity` asks the world the world to spawn a bee entity
> 
>     2. The world successfully spawns the entity
> 
>     3. The world tries to spawn the entity for the second time, but notices the UUID already exists. Therefore, the spawn fails and the method returns `false`
> 
>     4. This causes the beehive to assume that no bee was spawned and does not remove it from its internal list
> 
> 
> This also causes the dozens of duplicate UUID issues.
> 
> Simple fix is to remove that check and just call `addEntity0`, but I do not know if this has any other implications (which this check tries to fix).