### PR TITLE
Adjust ticks per entity spawns (#972)

### DIFF
--- a/src/main/resources/configurations/bukkit.yml
+++ b/src/main/resources/configurations/bukkit.yml
@@ -33,9 +33,9 @@ chunk-gc:
     period-in-ticks: 600
 ticks-per:
     animal-spawns: 400
-    monster-spawns: 400
-    water-spawns: 400
-    water-ambient-spawns: 400
-    ambient-spawns: 400
+    monster-spawns: 4
+    water-spawns: 1
+    water-ambient-spawns: 1
+    ambient-spawns: 1
     autosave: 6000
 aliases: now-in-commands.yml


### PR DESCRIPTION
This PR lowers mob spawn tickrates to more reasonable values, almost identical to the ones provided with [Paper](https://github.com/PaperMC/Paper).
People who stick with default values now shouldn't struggle with little to none mob spawns.