### PR TITLE
Revert tile entity injection

### DIFF
--- a/src/main/java/com/mohistmc/api/ServerAPI.java
+++ b/src/main/java/com/mohistmc/api/ServerAPI.java
@@ -16,7 +16,6 @@ public class ServerAPI {
     public static Map<String, String> forgecmdper = new ConcurrentHashMap();
     public static Map<String, String> forgecmd = new ConcurrentHashMap();
     public static Map<net.minecraft.entity.EntityType<?>, String> entityTypeMap = new ConcurrentHashMap<>();
-    public static Map<net.minecraft.tileentity.TileEntityType<?>, String> tileEntityTypeMap = new ConcurrentHashMap<>();
 
     // Don't count the default number of mods
     public static int getModSize() {

--- a/src/main/java/com/mohistmc/forge/ForgeInjectBukkit.java
+++ b/src/main/java/com/mohistmc/forge/ForgeInjectBukkit.java
@@ -20,7 +20,6 @@ import net.minecraft.item.Item;
 import net.minecraft.potion.Effect;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.BannerPattern;
-import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
@@ -66,7 +65,6 @@ public class ForgeInjectBukkit {
         addEnumPotion();
         addEnumPattern();
         addEnumEntity();
-        addEnumTileEntity();
         addEnumVillagerProfession();
         addEnumAttribute();
         addEnumArt();
@@ -254,23 +252,6 @@ public class ForgeInjectBukkit {
                 BY_ID.put(id, art);
                 MohistMC.LOGGER.debug("Registered forge PaintingType as Art {}", art);
                 i++;
-            }
-        }
-    }
-
-    public static void addEnumTileEntity() {
-        Map<String, EntityType> NAME_MAP = ObfuscationReflectionHelper.getPrivateValue(EntityType.class, null, "NAME_MAP");
-        Map<Short, EntityType> ID_MAP = ObfuscationReflectionHelper.getPrivateValue(EntityType.class, null, "ID_MAP");
-
-        for (Map.Entry<RegistryKey<TileEntityType<?>>, TileEntityType<?>> entity : ForgeRegistries.TILE_ENTITIES.getEntries()) {
-            ResourceLocation resourceLocation = entity.getValue().getRegistryName();
-            if (!resourceLocation.getNamespace().equals(NamespacedKey.MINECRAFT)) {
-                String entityType = normalizeName(resourceLocation.toString());
-                int typeId = entityType.hashCode();
-                EntityType bukkitType = MohistEnumHelper.addEnum0(EntityType.class, entityType, new Class[]{String.class, Class.class, Integer.TYPE, Boolean.TYPE}, entityType.toLowerCase(), CraftCustomEntity.class, typeId, false);
-                NAME_MAP.put(entityType.toLowerCase(), bukkitType);
-                ID_MAP.put((short) typeId, bukkitType);
-                ServerAPI.tileEntityTypeMap.put(entity.getValue(), entityType);
             }
         }
     }


### PR DESCRIPTION
I struggle to understand why this was even added in the first place, and propose to revert the changes.
Compilation of bad stuff coming from tile injection:
1) Bukkit doesn't even know the concept of "tile entity", and doesn't have the associated class for it (like EntityType for entities, for example). If plugins need access to tile entities (which is rarely the case), they gain access through NMS.
2) Injection of tile entities into EntityType class is strange, to say the least. EntityType is designed specifically for entities. Tile Entity and Entity are not the same concepts just because they both have "Entity" in their name.
3) Injection into EntityType breaks WorldEdit startup because of duplicate values, and possibly can break other plugins.