### PR TITLE
Paper patches

### DIFF
--- a/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/PathNavigator.java.patch
@@ -1,6 +1,46 @@
 --- a/net/minecraft/pathfinding/PathNavigator.java
 +++ b/net/minecraft/pathfinding/PathNavigator.java
-@@ -208,9 +208,9 @@
+@@ -11,6 +11,7 @@
+ import net.minecraft.entity.MobEntity;
+ import net.minecraft.entity.ai.attributes.Attributes;
+ import net.minecraft.network.DebugPacketSender;
++import net.minecraft.server.MinecraftServer;
+ import net.minecraft.util.Util;
+ import net.minecraft.util.math.BlockPos;
+ import net.minecraft.util.math.MathHelper;
+@@ -142,9 +143,30 @@
+       return this.func_75484_a(this.func_225466_a(p_75492_1_, p_75492_3_, p_75492_5_, 1), p_75492_7_);
+    }
+ 
++   // Paper start - Optimize Pathfinding
++   private int lastFailure = 0;
++   private int pathfindFailures = 0;
++   // Paper end
++
+    public boolean func_75497_a(Entity p_75497_1_, double p_75497_2_) {
++      // Paper start - Optimize Pathfinding
++      if (this.pathfindFailures > 10 && this.field_75514_c == null && MinecraftServer.currentTick < this.lastFailure + 40) {
++          return false;
++      }
++      // Paper end
+       Path path = this.func_75494_a(p_75497_1_, 1);
+-      return path != null && this.func_75484_a(path, p_75497_2_);
++
++      // Paper start - Optimize Pathfinding
++      if (path != null && this.func_75484_a(path, p_75497_2_)) {
++          this.lastFailure = 0;
++          this.pathfindFailures = 0;
++          return true;
++      } else {
++          this.pathfindFailures++;
++          this.lastFailure = MinecraftServer.currentTick;
++          return false;
++      }
++      // Paper end
+    }
+ 
+    public boolean func_75484_a(@Nullable Path p_75484_1_, double p_75484_2_) {
+@@ -208,9 +230,9 @@
        Vector3d vector3d = this.func_75502_i();
        this.field_188561_o = this.field_75515_a.func_213311_cf() > 0.75F ? this.field_75515_a.func_213311_cf() / 2.0F : 0.75F - this.field_75515_a.func_213311_cf() / 2.0F;
        Vector3i vector3i = this.field_75514_c.func_242948_g();

--- a/patches/minecraft/net/minecraft/util/math/shapes/IndirectMerger.java.patch
+++ b/patches/minecraft/net/minecraft/util/math/shapes/IndirectMerger.java.patch
@@ -1,0 +1,44 @@
+--- a/net/minecraft/util/math/shapes/IndirectMerger.java
++++ b/net/minecraft/util/math/shapes/IndirectMerger.java
+@@ -5,10 +5,16 @@
+ import it.unimi.dsi.fastutil.ints.IntArrayList;
+ 
+ public final class IndirectMerger implements IDoubleListMerger {
+-   private final DoubleArrayList field_197856_a;
++   private final DoubleList field_197856_a; // Paper - Optimize Voxel Shape Merging
+    private final IntArrayList field_197857_b;
+    private final IntArrayList field_197858_c;
+ 
++   // Paper start - Optimize Voxel Shape Merging
++   private static final IntArrayList INFINITE_B_1 = new IntArrayList(new int[]{1, 1});
++   private static final IntArrayList INFINITE_B_0 = new IntArrayList(new int[]{0, 0});
++   private static final IntArrayList INFINITE_C = new IntArrayList(new int[]{0, 1});
++   // Paper end
++
+    protected IndirectMerger(DoubleList p_i47685_1_, DoubleList p_i47685_2_, boolean p_i47685_3_, boolean p_i47685_4_) {
+       int i = 0;
+       int j = 0;
+@@ -16,6 +22,23 @@
+       int k = p_i47685_1_.size();
+       int l = p_i47685_2_.size();
+       int i1 = k + l;
++
++      // Paper start - Optimize Voxel Shape Merging
++      int size = p_i47685_1_.size();
++      double tail = p_i47685_1_.getDouble(size - 1);
++      double head = p_i47685_1_.getDouble(0);
++      if (head == Double.NEGATIVE_INFINITY && tail == Double.POSITIVE_INFINITY && !p_i47685_3_ && !p_i47685_4_ && (size == 2 || size == 4)) {
++          this.field_197856_a = p_i47685_2_;
++          if (size == 2) {
++              this.field_197857_b = INFINITE_B_0;
++          } else {
++              this.field_197857_b = INFINITE_B_1;
++          }
++          this.field_197858_c = INFINITE_C;
++          return;
++      }
++      // Paper end
++
+       this.field_197856_a = new DoubleArrayList(i1);
+       this.field_197857_b = new IntArrayList(i1);
+       this.field_197858_c = new IntArrayList(i1);

--- a/patches/minecraft/net/minecraft/util/math/shapes/VoxelShapes.java.patch
+++ b/patches/minecraft/net/minecraft/util/math/shapes/VoxelShapes.java.patch
@@ -1,0 +1,65 @@
+--- a/net/minecraft/util/math/shapes/VoxelShapes.java
++++ b/net/minecraft/util/math/shapes/VoxelShapes.java
+@@ -332,31 +332,48 @@
+       }
+    }
+ 
++   // Paper start - Optimize Voxel Shape Merging
+    @VisibleForTesting
+-   protected static IDoubleListMerger func_199410_a(int p_199410_0_, DoubleList p_199410_1_, DoubleList p_199410_2_, boolean p_199410_3_, boolean p_199410_4_) {
+-      int i = p_199410_1_.size() - 1;
+-      int j = p_199410_2_.size() - 1;
+-      if (p_199410_1_ instanceof DoubleRangeList && p_199410_2_ instanceof DoubleRangeList) {
++   private static IDoubleListMerger func_199410_a(int p_199410_0_, DoubleList p_199410_1_, DoubleList p_199410_2_, boolean p_199410_3_, boolean p_199410_4_) {
++       // fast track the most common scenario
++       // doublelist is usually a DoubleArrayList with Infinite head/tails that falls to the final else clause
++       // This is actually the most common path, so jump to it straight away
++       if (p_199410_1_.getDouble(0) == Double.NEGATIVE_INFINITY && p_199410_1_.getDouble(p_199410_1_.size() - 1) == Double.POSITIVE_INFINITY) {
++           return new IndirectMerger(p_199410_1_, p_199410_2_, p_199410_3_, p_199410_4_);
++       }
++       // Split out rest to hopefully inline the above
++       return lessCommonMerge(p_199410_0_, p_199410_1_, p_199410_2_, p_199410_3_, p_199410_4_);
++   }
++
++   private static IDoubleListMerger lessCommonMerge(int p_199410_0_, DoubleList list1, DoubleList list2, boolean p_199410_3_, boolean p_199410_4_) {
++      int i = list1.size() - 1;
++      int j = list2.size() - 1;
++      if (list1 instanceof DoubleRangeList && list2 instanceof DoubleRangeList) {
+          long k = func_197877_a(i, j);
+          if ((long)p_199410_0_ * k <= 256L) {
+             return new DoubleCubeMergingList(i, j);
+          }
+       }
+ 
+-      if (p_199410_1_.getDouble(i) < p_199410_2_.getDouble(0) - 1.0E-7D) {
+-         return new NonOverlappingMerger(p_199410_1_, p_199410_2_, false);
+-      } else if (p_199410_2_.getDouble(j) < p_199410_1_.getDouble(0) - 1.0E-7D) {
+-         return new NonOverlappingMerger(p_199410_2_, p_199410_1_, true);
+-      } else if (i == j && Objects.equals(p_199410_1_, p_199410_2_)) {
+-         if (p_199410_1_ instanceof SimpleDoubleMerger) {
+-            return (IDoubleListMerger)p_199410_1_;
+-         } else {
+-            return (IDoubleListMerger)(p_199410_2_ instanceof SimpleDoubleMerger ? (IDoubleListMerger)p_199410_2_ : new SimpleDoubleMerger(p_199410_1_));
++      // Rewrite below as optimized order if instead of nasty ternary
++      // Identical happens more often than Disjoint
++      if (i == j && Objects.equals(list1, list2)) {
++         if (list1 instanceof SimpleDoubleMerger) {
++            return (IDoubleListMerger)list1;
++         } else if (list2 instanceof SimpleDoubleMerger) {
++            return (IDoubleListMerger)list2;
+          }
++         return new SimpleDoubleMerger(list1);
++      }
++      else if (list1.getDouble(i) < list2.getDouble(0) - 1.0E-7D) {
++         return new NonOverlappingMerger(list1, list2, false);
++      } else if (list2.getDouble(j) < list1.getDouble(0) - 1.0E-7D) {
++         return new NonOverlappingMerger(list2, list1, true);
+       } else {
+-         return new IndirectMerger(p_199410_1_, p_199410_2_, p_199410_3_, p_199410_4_);
++         return new IndirectMerger(list1, list2, p_199410_3_, p_199410_4_);
+       }
+    }
++   // Paper end
+ 
+    public interface ILineConsumer {
+       void consume(double p_consume_1_, double p_consume_3_, double p_consume_5_, double p_consume_7_, double p_consume_9_, double p_consume_11_);

--- a/patches/minecraft/net/minecraft/util/palette/PalettedContainer.java.patch
+++ b/patches/minecraft/net/minecraft/util/palette/PalettedContainer.java.patch
@@ -41,3 +41,22 @@
     }
  
     public void func_186009_b(PacketBuffer p_186009_1_) {
+@@ -233,6 +242,18 @@
+       });
+    }
+ 
++   // Paper start - Optimise random block ticking
++   public void forEachLocation(PalettedContainer.ICountConsumer<T> countConsumerIn) {
++      Int2IntMap int2intmap = new Int2IntOpenHashMap();
++      this.field_186021_b.func_225421_a((p_225498_1_) -> {
++         int2intmap.put(p_225498_1_, int2intmap.get(p_225498_1_) + 1);
++      });
++      int2intmap.int2IntEntrySet().forEach((p_225499_2_) -> {
++         countConsumerIn.accept(this.field_186022_c.func_186039_a(p_225499_2_.getIntKey()), p_225499_2_.getIntKey());
++      });
++   }
++   // Paper end
++
+    @FunctionalInterface
+    public interface ICountConsumer<T> {
+       void accept(T p_accept_1_, int p_accept_2_);

--- a/patches/minecraft/net/minecraft/world/chunk/ChunkSection.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/ChunkSection.java.patch
@@ -1,6 +1,16 @@
 --- a/net/minecraft/world/chunk/ChunkSection.java
 +++ b/net/minecraft/world/chunk/ChunkSection.java
-@@ -15,7 +15,7 @@
+@@ -2,6 +2,9 @@
+ 
+ import java.util.function.Predicate;
+ import javax.annotation.Nullable;
++
++import com.destroystokyo.paper.util.maplist.IBlockDataList;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.block.BlockState;
+ import net.minecraft.block.Blocks;
+@@ -15,12 +18,13 @@
  import net.minecraftforge.api.distmarker.OnlyIn;
  
  public class ChunkSection {
@@ -9,3 +19,61 @@
     private final int field_76684_a;
     private short field_76682_b;
     private short field_76683_c;
+    private short field_206918_e;
+    private final PalettedContainer<BlockState> field_177488_d;
++   public final IBlockDataList tickableBlocks = new IBlockDataList(); // Paper - Optimise random block ticking
+ 
+    public ChunkSection(int p_i49943_1_) {
+       this(p_i49943_1_, (short)0, (short)0, (short)0);
+@@ -68,6 +72,7 @@
+          --this.field_76682_b;
+          if (blockstate.func_204519_t()) {
+             --this.field_76683_c;
++            this.tickableBlocks.remove(p_177484_1_, p_177484_2_, p_177484_3_); // Paper - Optimise random block ticking
+          }
+       }
+ 
+@@ -79,6 +84,7 @@
+          ++this.field_76682_b;
+          if (p_177484_4_.func_204519_t()) {
+             ++this.field_76683_c;
++            this.tickableBlocks.add(p_177484_1_, p_177484_2_, p_177484_3_, p_177484_4_); // Paper - Optimise random block ticking
+          }
+       }
+ 
+@@ -114,26 +120,30 @@
+    }
+ 
+    public void func_76672_e() {
++      this.tickableBlocks.clear(); // Paper - Optimise random block ticking
+       this.field_76682_b = 0;
+       this.field_76683_c = 0;
+       this.field_206918_e = 0;
+-      this.field_177488_d.func_225497_a((p_225496_1_, p_225496_2_) -> {
++      // Paper start - Optimise random block ticking
++      this.field_177488_d.forEachLocation((p_225496_1_, p_225496_2_) -> {
+          FluidState fluidstate = p_225496_1_.func_204520_s();
+          if (!p_225496_1_.func_196958_f()) {
+-            this.field_76682_b = (short)(this.field_76682_b + p_225496_2_);
++            this.field_76682_b = (short)(this.field_76682_b + 1);
+             if (p_225496_1_.func_204519_t()) {
+-               this.field_76683_c = (short)(this.field_76683_c + p_225496_2_);
++               this.field_76683_c = (short)(this.field_76683_c + 1);
++               this.tickableBlocks.add(p_225496_2_, p_225496_1_);
+             }
+          }
+ 
+          if (!fluidstate.func_206888_e()) {
+-            this.field_76682_b = (short)(this.field_76682_b + p_225496_2_);
++            this.field_76682_b = (short)(this.field_76682_b + 1);
+             if (fluidstate.func_206890_h()) {
+-               this.field_206918_e = (short)(this.field_206918_e + p_225496_2_);
++               this.field_206918_e = (short)(this.field_206918_e + 1);
+             }
+          }
+ 
+       });
++      // Paper end
+    }
+ 
+    public PalettedContainer<BlockState> func_186049_g() {

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -1,6 +1,13 @@
 --- a/net/minecraft/world/server/ServerWorld.java
 +++ b/net/minecraft/world/server/ServerWorld.java
-@@ -6,6 +6,8 @@
+@@ -1,11 +1,15 @@
+ package net.minecraft.world.server;
+ 
++import com.destroystokyo.paper.util.maplist.IBlockDataList;
++import com.destroystokyo.paper.util.math.ThreadUnsafeRandom;
+ import com.google.common.annotations.VisibleForTesting;
+ import com.google.common.collect.Iterables;
+ import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Queues;
  import com.google.common.collect.Sets;
@@ -9,7 +16,7 @@
  import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
  import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
  import it.unimi.dsi.fastutil.ints.Int2ObjectMap.Entry;
-@@ -18,19 +20,12 @@
+@@ -18,19 +22,12 @@
  import java.io.Writer;
  import java.nio.file.Files;
  import java.nio.file.Path;
@@ -31,7 +38,7 @@
  import java.util.stream.Collectors;
  import java.util.stream.Stream;
  import javax.annotation.Nonnull;
-@@ -39,6 +34,7 @@
+@@ -39,6 +36,7 @@
  import net.minecraft.block.BlockEventData;
  import net.minecraft.block.BlockState;
  import net.minecraft.block.Blocks;
@@ -39,7 +46,7 @@
  import net.minecraft.crash.CrashReport;
  import net.minecraft.entity.Entity;
  import net.minecraft.entity.EntityClassification;
-@@ -51,6 +47,8 @@
+@@ -51,6 +49,8 @@
  import net.minecraft.entity.effect.LightningBoltEntity;
  import net.minecraft.entity.merchant.IReputationTracking;
  import net.minecraft.entity.merchant.IReputationType;
@@ -48,7 +55,7 @@
  import net.minecraft.entity.passive.AnimalEntity;
  import net.minecraft.entity.passive.WaterMobEntity;
  import net.minecraft.entity.passive.horse.SkeletonHorseEntity;
-@@ -59,6 +57,7 @@
+@@ -59,6 +59,7 @@
  import net.minecraft.fluid.Fluid;
  import net.minecraft.fluid.FluidState;
  import net.minecraft.fluid.Fluids;
@@ -56,7 +63,7 @@
  import net.minecraft.item.crafting.RecipeManager;
  import net.minecraft.network.DebugPacketSender;
  import net.minecraft.network.IPacket;
-@@ -79,17 +78,7 @@
+@@ -79,17 +80,7 @@
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.tags.ITagCollectionSupplier;
  import net.minecraft.tileentity.TileEntity;
@@ -75,7 +82,7 @@
  import net.minecraft.util.math.AxisAlignedBB;
  import net.minecraft.util.math.BlockPos;
  import net.minecraft.util.math.ChunkPos;
-@@ -133,27 +122,33 @@
+@@ -133,27 +124,33 @@
  import net.minecraft.world.raid.RaidManager;
  import net.minecraft.world.spawner.ISpecialSpawner;
  import net.minecraft.world.spawner.WorldEntitySpawner;
@@ -117,7 +124,7 @@
     public boolean field_73058_d;
     private boolean field_73068_P;
     private int field_80004_Q;
-@@ -173,9 +168,31 @@
+@@ -173,9 +170,31 @@
     private final DragonFightManager field_241105_O_;
     private final StructureManager field_241106_P_;
     private final boolean field_241107_Q_;
@@ -149,7 +156,7 @@
        this.field_241107_Q_ = p_i241885_13_;
        this.field_73061_a = p_i241885_1_;
        this.field_241104_N_ = p_i241885_12_;
-@@ -200,9 +217,33 @@
+@@ -200,9 +219,33 @@
        } else {
           this.field_241105_O_ = null;
        }
@@ -183,7 +190,7 @@
     public void func_241113_a_(int p_241113_1_, int p_241113_2_, boolean p_241113_3_, boolean p_241113_4_) {
        this.field_241103_E_.func_230391_a_(p_241113_1_);
        this.field_241103_E_.func_76080_g(p_241113_2_);
-@@ -211,6 +252,7 @@
+@@ -211,6 +254,7 @@
        this.field_241103_E_.func_76069_a(p_241113_4_);
     }
  
@@ -191,7 +198,7 @@
     public Biome func_225604_a_(int p_225604_1_, int p_225604_2_, int p_225604_3_) {
        return this.func_72863_F().func_201711_g().func_202090_b().func_225526_b_(p_225604_1_, p_225604_2_, p_225604_3_);
     }
-@@ -296,27 +338,39 @@
+@@ -296,27 +340,39 @@
           this.field_73061_a.func_184103_al().func_232642_a_(new SChangeGameStatePacket(SChangeGameStatePacket.field_241772_i_, this.field_73017_q), this.func_234923_W_());
        }
  
@@ -240,7 +247,7 @@
           if (this.func_82736_K().func_223586_b(GameRules.field_223617_t)) {
              this.func_73051_P();
           }
-@@ -327,23 +381,28 @@
+@@ -327,23 +383,28 @@
        iprofiler.func_219895_b("chunkSource");
        this.func_72863_F().func_217207_a(p_72835_1_);
        iprofiler.func_219895_b("tickPending");
@@ -270,7 +277,7 @@
           if (this.field_241105_O_ != null) {
              this.field_241105_O_.func_186105_b();
           }
-@@ -351,18 +410,22 @@
+@@ -351,18 +412,22 @@
           this.field_217492_a = true;
           ObjectIterator<Entry<Entity>> objectiterator = this.field_217498_x.int2ObjectEntrySet().iterator();
  
@@ -293,7 +300,7 @@
                    this.func_217391_K();
                    break label164;
                 }
-@@ -395,7 +458,7 @@
+@@ -395,7 +460,7 @@
              }
  
              iprofiler.func_76320_a("tick");
@@ -302,7 +309,7 @@
                 this.func_217390_a(this::func_217479_a, entity1);
              }
  
-@@ -404,7 +467,7 @@
+@@ -404,7 +469,7 @@
              if (entity1.field_70128_L) {
                 this.func_217454_n(entity1);
                 objectiterator.remove();
@@ -311,7 +318,16 @@
              }
  
              iprofiler.func_76319_b();
-@@ -460,13 +523,13 @@
+@@ -443,6 +508,8 @@
+       });
+    }
+ 
++   private final ThreadUnsafeRandom randomTickRandom = new ThreadUnsafeRandom(); // Paper start - Optimise random block ticking
++
+    public void func_217441_a(Chunk p_217441_1_, int p_217441_2_) {
+       ChunkPos chunkpos = p_217441_1_.func_76632_l();
+       boolean flag = this.func_72896_J();
+@@ -460,13 +527,13 @@
                 skeletonhorseentity.func_190691_p(true);
                 skeletonhorseentity.func_70873_a(0);
                 skeletonhorseentity.func_70107_b((double)blockpos.func_177958_n(), (double)blockpos.func_177956_o(), (double)blockpos.func_177952_p());
@@ -327,7 +343,7 @@
           }
        }
  
-@@ -475,12 +538,13 @@
+@@ -475,12 +542,13 @@
           BlockPos blockpos2 = this.func_205770_a(Heightmap.Type.MOTION_BLOCKING, this.func_217383_a(i, 0, j, 15));
           BlockPos blockpos3 = blockpos2.func_177977_b();
           Biome biome = this.func_226691_t_(blockpos2);
@@ -343,7 +359,68 @@
           }
  
           if (flag && this.func_226691_t_(blockpos3).func_201851_b() == Biome.RainType.RAIN) {
-@@ -544,7 +608,7 @@
+@@ -488,32 +556,38 @@
+          }
+       }
+ 
+-      iprofiler.func_219895_b("tickBlocks");
++      // Paper start - Optimise random block ticking
++      iprofiler.func_76319_b();
+       if (p_217441_2_ > 0) {
+-         for(ChunkSection chunksection : p_217441_1_.func_76587_i()) {
+-            if (chunksection != Chunk.field_186036_a && chunksection.func_206915_b()) {
+-               int k = chunksection.func_222632_g();
+-
+-               for(int l = 0; l < p_217441_2_; ++l) {
+-                  BlockPos blockpos1 = this.func_217383_a(i, k, j, 15);
+-                  iprofiler.func_76320_a("randomTick");
+-                  BlockState blockstate = chunksection.func_177485_a(blockpos1.func_177958_n() - i, blockpos1.func_177956_o() - k, blockpos1.func_177952_p() - j);
+-                  if (blockstate.func_204519_t()) {
+-                     blockstate.func_227034_b_(this, blockpos1, this.field_73012_v);
+-                  }
+-
+-                  FluidState fluidstate = blockstate.func_204520_s();
+-                  if (fluidstate.func_206890_h()) {
+-                     fluidstate.func_206891_b(this, blockpos1, this.field_73012_v);
+-                  }
+-
+-                  iprofiler.func_76319_b();
+-               }
++         iprofiler.func_76320_a("randomTick");
++         ChunkSection[] sections = p_217441_1_.func_76587_i();
++         for (int sectionIndex = 0; sectionIndex < 16; ++sectionIndex) {
++            ChunkSection section = sections[sectionIndex];
++            if (section == null || section.tickableBlocks.size() == 0) {
++                continue;
+             }
++            int yPos = sectionIndex << 4;
++            for (int a = 0; a < p_217441_2_; ++a) {
++                int tickingBlocks = section.tickableBlocks.size();
++                int index = this.randomTickRandom.nextInt(16 * 16 * 16);
++                if (index >= tickingBlocks) {
++                    continue;
++                }
++                long raw = section.tickableBlocks.getRaw(index);
++                int location = IBlockDataList.getLocationFromRaw(raw);
++                int randomX = location & 15;
++                int randomY = ((location >>> (4 + 4)) & 255) | yPos;
++                int randomZ = (location >>> 4) & 15;
++                BlockPos pos = new BlockPos(i + randomX, randomY, j + randomZ);
++                BlockState state = IBlockDataList.getBlockDataFromRaw(raw);
++                state.func_227034_b_(this, pos, randomTickRandom);
++                // We drop the fluid tick since LAVA is ALREADY TICKED by the above method.
++                // TODO CHECK ON UPDATE
++            }
+          }
++         iprofiler.func_76319_b();
+       }
+-
+-      iprofiler.func_76319_b();
++      // Paper end
+    }
+ 
+    protected BlockPos func_175736_a(BlockPos p_175736_1_) {
+@@ -544,7 +618,7 @@
           int j = 0;
  
           for(ServerPlayerEntity serverplayerentity : this.field_217491_A) {
@@ -352,7 +429,7 @@
                 ++i;
              } else if (serverplayerentity.func_70608_bn()) {
                 ++j;
-@@ -561,10 +625,22 @@
+@@ -561,10 +635,22 @@
     }
  
     private void func_73051_P() {
@@ -377,7 +454,7 @@
     }
  
     public void func_82742_i() {
-@@ -591,6 +667,14 @@
+@@ -591,6 +677,14 @@
        if (!(p_217479_1_ instanceof PlayerEntity) && !this.func_72863_F().func_217204_a(p_217479_1_)) {
           this.func_217464_b(p_217479_1_);
        } else {
@@ -392,7 +469,7 @@
           p_217479_1_.func_226286_f_(p_217479_1_.func_226277_ct_(), p_217479_1_.func_226278_cu_(), p_217479_1_.func_226281_cx_());
           p_217479_1_.field_70126_B = p_217479_1_.field_70177_z;
           p_217479_1_.field_70127_C = p_217479_1_.field_70125_A;
-@@ -598,10 +682,12 @@
+@@ -598,10 +692,12 @@
              ++p_217479_1_.field_70173_aa;
              IProfiler iprofiler = this.func_217381_Z();
              iprofiler.func_194340_a(() -> {
@@ -406,7 +483,7 @@
              iprofiler.func_76319_b();
           }
  
-@@ -611,6 +697,7 @@
+@@ -611,6 +707,7 @@
                 this.func_217459_a(p_217479_1_, entity);
              }
           }
@@ -414,7 +491,7 @@
  
        }
     }
-@@ -629,6 +716,7 @@
+@@ -629,6 +726,7 @@
                 });
                 iprofiler.func_230035_c_("tickPassenger");
                 p_217459_2_.func_70098_U();
@@ -422,7 +499,7 @@
                 iprofiler.func_76319_b();
              }
  
-@@ -649,7 +737,7 @@
+@@ -649,7 +747,7 @@
        if (p_217464_1_.func_233578_ci_()) {
           this.func_217381_Z().func_76320_a("chunkCheck");
           int i = MathHelper.func_76128_c(p_217464_1_.func_226277_ct_() / 16.0D);
@@ -431,7 +508,7 @@
           int k = MathHelper.func_76128_c(p_217464_1_.func_226281_cx_() / 16.0D);
           if (!p_217464_1_.field_70175_ag || p_217464_1_.field_70176_ah != i || p_217464_1_.field_70162_ai != j || p_217464_1_.field_70164_aj != k) {
              if (p_217464_1_.field_70175_ag && this.func_217354_b(p_217464_1_.field_70176_ah, p_217464_1_.field_70164_aj)) {
-@@ -658,7 +746,7 @@
+@@ -658,7 +756,7 @@
  
              if (!p_217464_1_.func_233577_ch_() && !this.func_217354_b(i, k)) {
                 if (p_217464_1_.field_70175_ag) {
@@ -440,7 +517,7 @@
                 }
  
                 p_217464_1_.field_70175_ag = false;
-@@ -678,6 +766,7 @@
+@@ -678,6 +776,7 @@
     public void func_217445_a(@Nullable IProgressUpdate p_217445_1_, boolean p_217445_2_, boolean p_217445_3_) {
        ServerChunkProvider serverchunkprovider = this.func_72863_F();
        if (!p_217445_3_) {
@@ -448,7 +525,7 @@
           if (p_217445_1_ != null) {
              p_217445_1_.func_200210_a(new TranslationTextComponent("menu.savingLevel"));
           }
-@@ -687,6 +776,7 @@
+@@ -687,6 +786,7 @@
              p_217445_1_.func_200209_c(new TranslationTextComponent("menu.savingChunks"));
           }
  
@@ -456,7 +533,7 @@
           serverchunkprovider.func_217210_a(p_217445_2_);
        }
     }
-@@ -743,13 +833,23 @@
+@@ -743,13 +843,23 @@
     }
  
     public boolean func_217376_c(Entity p_217376_1_) {
@@ -482,7 +559,7 @@
     public void func_217460_e(Entity p_217460_1_) {
        boolean flag = p_217460_1_.field_98038_p;
        p_217460_1_.field_98038_p = true;
-@@ -777,9 +877,10 @@
+@@ -777,9 +887,10 @@
     }
  
     private void func_217448_f(ServerPlayerEntity p_217448_1_) {
@@ -494,7 +571,7 @@
           entity.func_213319_R();
           this.func_217434_e((ServerPlayerEntity)entity);
        }
-@@ -795,18 +896,24 @@
+@@ -795,18 +906,24 @@
     }
  
     private boolean func_72838_d(Entity p_72838_1_) {
@@ -525,7 +602,7 @@
              return true;
           }
        }
-@@ -816,6 +923,7 @@
+@@ -816,6 +933,7 @@
        if (this.func_217478_l(p_217440_1_)) {
           return false;
        } else {
@@ -533,7 +610,7 @@
           this.func_217465_m(p_217440_1_);
           return true;
        }
-@@ -827,7 +935,7 @@
+@@ -827,7 +945,7 @@
        if (entity == null) {
           return false;
        } else {
@@ -542,7 +619,7 @@
           return true;
        }
     }
-@@ -851,15 +959,30 @@
+@@ -851,15 +969,30 @@
     }
  
     public boolean func_242106_g(Entity p_242106_1_) {
@@ -575,7 +652,7 @@
        this.field_147483_b.addAll(p_217466_1_.func_177434_r().values());
        ClassInheritanceMultiMap<Entity>[] aclassinheritancemultimap = p_217466_1_.func_177429_s();
        int i = aclassinheritancemultimap.length;
-@@ -879,12 +1002,41 @@
+@@ -879,12 +1012,41 @@
  
     }
  
@@ -618,7 +695,7 @@
  
        this.field_175741_N.remove(p_217484_1_.func_110124_au());
        this.func_72863_F().func_217226_b(p_217484_1_);
-@@ -894,10 +1046,19 @@
+@@ -894,10 +1056,19 @@
        }
  
        this.func_96441_U().func_181140_a(p_217484_1_);
@@ -638,7 +715,7 @@
     }
  
     private void func_217465_m(Entity p_217465_1_) {
-@@ -913,20 +1074,31 @@
+@@ -913,20 +1084,31 @@
  
           this.field_175741_N.put(p_217465_1_.func_110124_au(), p_217465_1_);
           this.func_72863_F().func_217230_c(p_217465_1_);
@@ -671,7 +748,7 @@
        }
     }
  
-@@ -939,17 +1111,47 @@
+@@ -939,17 +1121,47 @@
     }
  
     public void func_217434_e(ServerPlayerEntity p_217434_1_) {
@@ -721,7 +798,7 @@
              if (d0 * d0 + d1 * d1 + d2 * d2 < 1024.0D) {
                 serverplayerentity.field_71135_a.func_147359_a(new SAnimateBlockBreakPacket(p_175715_1_, p_175715_2_, p_175715_3_));
              }
-@@ -959,10 +1161,20 @@
+@@ -959,10 +1171,20 @@
     }
  
     public void func_184148_a(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {
@@ -742,7 +819,7 @@
        this.field_73061_a.func_184103_al().func_148543_a(p_217384_1_, p_217384_2_.func_226277_ct_(), p_217384_2_.func_226278_cu_(), p_217384_2_.func_226281_cx_(), p_217384_5_ > 1.0F ? (double)(16.0F * p_217384_5_) : 16.0D, this.func_234923_W_(), new SSpawnMovingSoundEffectPacket(p_217384_3_, p_217384_4_, p_217384_2_, p_217384_5_, p_217384_6_));
     }
  
-@@ -997,9 +1209,17 @@
+@@ -997,9 +1219,17 @@
     }
  
     public Explosion func_230546_a_(@Nullable Entity p_230546_1_, @Nullable DamageSource p_230546_2_, @Nullable ExplosionContext p_230546_3_, double p_230546_4_, double p_230546_6_, double p_230546_8_, float p_230546_10_, boolean p_230546_11_, Explosion.Mode p_230546_12_) {
@@ -763,7 +840,7 @@
        if (p_230546_12_ == Explosion.Mode.NONE) {
           explosion.func_180342_d();
        }
-@@ -1054,12 +1274,19 @@
+@@ -1054,12 +1284,19 @@
     }
  
     public <T extends IParticleData> int func_195598_a(T p_195598_1_, double p_195598_2_, double p_195598_4_, double p_195598_6_, int p_195598_8_, double p_195598_9_, double p_195598_11_, double p_195598_13_, double p_195598_15_) {
@@ -785,7 +862,7 @@
              ++i;
           }
        }
-@@ -1131,7 +1358,13 @@
+@@ -1131,7 +1368,13 @@
     @Nullable
     public MapData func_217406_a(String p_217406_1_) {
        return this.func_73046_m().func_241755_D_().func_217481_x().func_215753_b(() -> {
@@ -800,7 +877,7 @@
        }, p_217406_1_);
     }
  
-@@ -1333,6 +1566,11 @@
+@@ -1333,6 +1576,11 @@
  
     public void func_230547_a_(BlockPos p_230547_1_, Block p_230547_2_) {
        if (!this.func_234925_Z_()) {
@@ -812,7 +889,7 @@
           this.func_195593_d(p_230547_1_, p_230547_2_);
        }
  
-@@ -1399,15 +1637,44 @@
+@@ -1399,15 +1647,44 @@
     }
  
     public static void func_241121_a_(ServerWorld p_241121_0_) {

--- a/src/main/java/com/destroystokyo/paper/util/maplist/IBlockDataList.java
+++ b/src/main/java/com/destroystokyo/paper/util/maplist/IBlockDataList.java
@@ -1,0 +1,130 @@
+package com.destroystokyo.paper.util.maplist;
+
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.shorts.Short2LongOpenHashMap;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.palette.IPalette;
+import net.minecraft.world.chunk.ChunkSection;
+
+import java.util.Arrays;
+
+/**
+ * @author Spottedleaf
+ */
+public final class IBlockDataList {
+
+    static final IPalette<BlockState> GLOBAL_PALETTE = ChunkSection.REGISTRY_PALETTE;
+
+    // map of location -> (index | (location << 16) | (palette id << 32))
+    private final Short2LongOpenHashMap map = new Short2LongOpenHashMap(2, 0.8f);
+    {
+        this.map.defaultReturnValue(Long.MAX_VALUE);
+    }
+
+    private static final long[] EMPTY_LIST = new long[0];
+
+    private long[] byIndex = EMPTY_LIST;
+    private int size;
+
+    public static int getLocationKey(final int x, final int y, final int z) {
+        return (x & 15) | (((z & 15) << 4)) | ((y & 255) << (4 + 4));
+    }
+
+    public static BlockState getBlockDataFromRaw(final long raw) {
+        return GLOBAL_PALETTE.get((int)(raw >>> 32));
+    }
+
+    public static int getIndexFromRaw(final long raw) {
+        return (int)(raw & 0xFFFF);
+    }
+
+    public static int getLocationFromRaw(final long raw) {
+        return (int)((raw >>> 16) & 0xFFFF);
+    }
+
+    public static long getRawFromValues(final int index, final int location, final BlockState data) {
+        return (long)index | ((long)location << 16) | (((long)GLOBAL_PALETTE.idFor(data)) << 32);
+    }
+
+    public static long setIndexRawValues(final long value, final int index) {
+        return value & ~(0xFFFF) | (index);
+    }
+
+    public long add(final int x, final int y, final int z, final BlockState data) {
+        return this.add(getLocationKey(x, y, z), data);
+    }
+
+    public long add(final int location, final BlockState data) {
+        final long curr = this.map.get((short)location);
+
+        if (curr == Long.MAX_VALUE) {
+            final int index = this.size++;
+            final long raw = getRawFromValues(index, location, data);
+            this.map.put((short)location, raw);
+
+            if (index >= this.byIndex.length) {
+                this.byIndex = Arrays.copyOf(this.byIndex, (int)Math.max(4L, this.byIndex.length * 2L));
+            }
+
+            this.byIndex[index] = raw;
+            return raw;
+        } else {
+            final int index = getIndexFromRaw(curr);
+            final long raw = this.byIndex[index] = getRawFromValues(index, location, data);
+
+            this.map.put((short)location, raw);
+
+            return raw;
+        }
+    }
+
+    public long remove(final int x, final int y, final int z) {
+        return this.remove(getLocationKey(x, y, z));
+    }
+
+    public long remove(final int location) {
+        final long ret = this.map.remove((short)location);
+        final int index = getIndexFromRaw(ret);
+        if (ret == Long.MAX_VALUE) {
+            return ret;
+        }
+
+        // move the entry at the end to this index
+        final int endIndex = --this.size;
+        final long end = this.byIndex[endIndex];
+        if (index != endIndex) {
+            // not empty after this call
+            this.map.put((short)getLocationFromRaw(end), setIndexRawValues(end, index));
+        }
+        this.byIndex[index] = end;
+        this.byIndex[endIndex] = 0L;
+
+        return ret;
+    }
+
+    public int size() {
+        return this.size;
+    }
+
+    public long getRaw(final int index) {
+        return this.byIndex[index];
+    }
+
+    public int getLocation(final int index) {
+        return getLocationFromRaw(this.getRaw(index));
+    }
+
+    public BlockState getData(final int index) {
+        return getBlockDataFromRaw(this.getRaw(index));
+    }
+
+    public void clear() {
+        this.size = 0;
+        this.map.clear();
+    }
+
+    public LongIterator getRawIterator() {
+        return this.map.values().iterator();
+    }
+
+}

--- a/src/main/java/com/destroystokyo/paper/util/math/ThreadUnsafeRandom.java
+++ b/src/main/java/com/destroystokyo/paper/util/math/ThreadUnsafeRandom.java
@@ -1,0 +1,48 @@
+package com.destroystokyo.paper.util.math;
+
+import java.util.Random;
+
+@SuppressWarnings("serial")
+public final class ThreadUnsafeRandom extends Random {
+
+    // See javadoc and internal comments for java.util.Random where these values come from, how they are used, and the author for them.
+    private static final long multiplier = 0x5DEECE66DL;
+    private static final long addend = 0xBL;
+    private static final long mask = (1L << 48) - 1;
+
+    private static long initialScramble(long seed) {
+        return (seed ^ multiplier) & mask;
+    }
+
+    private long seed;
+
+    @Override
+    public void setSeed(long seed) {
+        // note: called by Random constructor
+        this.seed = initialScramble(seed);
+    }
+
+    @Override
+    protected int next(int bits) {
+        // avoid the expensive CAS logic used by superclass
+        return (int) (((this.seed = this.seed * multiplier + addend) & mask) >>> (48 - bits));
+    }
+
+    // Taken from
+    // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+    // https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/blob/master/2016/06/25/fastrange.c
+    // Original license is public domain
+    public static int fastRandomBounded(final long randomInteger, final long limit) {
+        // randomInteger must be [0, pow(2, 32))
+        // limit must be [0, pow(2, 32))
+        return (int)((randomInteger * limit) >>> 32);
+    }
+
+    @Override
+    public int nextInt(int bound) {
+        // yes this breaks random's spec
+        // however there's nothing that uses this class that relies on it
+        return fastRandomBounded(this.next(32) & 0xFFFFFFFFL, bound);
+    }
+
+}

--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import net.minecraft.command.CommandSource; // CraftBukkit
 
 public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
-    private Map<String, CommandNode<S>> children = Maps.newLinkedHashMap();
+    private Map<String, CommandNode<S>> children = Maps.newTreeMap(); // Paper - Optimize brigadier child sorting performance
     private Map<String, LiteralCommandNode<S>> literals = Maps.newLinkedHashMap();
     private Map<String, ArgumentCommandNode<S, ?>> arguments = Maps.newLinkedHashMap();
     private final Predicate<S> requirement;
@@ -108,7 +108,9 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
             }
         }
 
-        children = children.entrySet().stream().sorted(Map.Entry.comparingByValue()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
+        // Paper start - Optimize brigadier child sorting performance
+        // children = children.entrySet().stream().sorted(Map.Entry.comparingByValue()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
+        // Paper end
     }
 
     public void findAmbiguities(final AmbiguityConsumer<S> consumer) {


### PR DESCRIPTION
4 ported patches from [Paper](https://github.com/PaperMC/Paper) which provide better server performance.
1. https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0408-Optimise-random-block-ticking.patch
2. https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0474-Optimize-brigadier-child-sorting-performance.patch
3. https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0464-Optimize-Voxel-Shape-Merging.patch
4. https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0439-Optimize-Pathfinding.patch