### PR TITLE
Misc stuff

### DIFF
--- a/patches/minecraft/net/minecraft/util/palette/PalettedContainer.java.patch
+++ b/patches/minecraft/net/minecraft/util/palette/PalettedContainer.java.patch
@@ -41,18 +41,18 @@
     }
  
     public void func_186009_b(PacketBuffer p_186009_1_) {
-@@ -233,6 +242,18 @@
+@@ -233,8 +242,28 @@
        });
     }
  
 +   // Paper start - Optimise random block ticking
-+   public void forEachLocation(PalettedContainer.ICountConsumer<T> countConsumerIn) {
++   public void forEachLocation(PalettedContainer.ICountConsumerTriple<T> countConsumerIn) {
 +      Int2IntMap int2intmap = new Int2IntOpenHashMap();
 +      this.field_186021_b.func_225421_a((p_225498_1_) -> {
 +         int2intmap.put(p_225498_1_, int2intmap.get(p_225498_1_) + 1);
 +      });
 +      int2intmap.int2IntEntrySet().forEach((p_225499_2_) -> {
-+         countConsumerIn.accept(this.field_186022_c.func_186039_a(p_225499_2_.getIntKey()), p_225499_2_.getIntKey());
++         countConsumerIn.accept(this.field_186022_c.func_186039_a(p_225499_2_.getIntKey()), p_225499_2_.getIntKey(), p_225499_2_.getIntValue());
 +      });
 +   }
 +   // Paper end
@@ -60,3 +60,13 @@
     @FunctionalInterface
     public interface ICountConsumer<T> {
        void accept(T p_accept_1_, int p_accept_2_);
+    }
++
++   // Mohist start - Fix phantom blocks after explosion
++   @FunctionalInterface
++   public interface ICountConsumerTriple<T> {
++      void accept(T arg1, int arg2, int arg3);
++   }
++   // Mohist end
++
+ }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -520,13 +520,12 @@
                 }
              }
           }
-@@ -490,17 +724,24 @@
+@@ -490,17 +724,23 @@
           this.field_147484_a.clear();
        }
  
 +      timings.tileEntityPending.stopTiming(); // Spigot
        iprofiler.func_76319_b();
-+      spigotConfig.currentPrimedTnt = 0; // Spigot
     }
  
     public void func_217390_a(Consumer<Entity> p_217390_1_, Entity p_217390_2_) {
@@ -545,7 +544,7 @@
        }
     }
  
-@@ -514,6 +755,7 @@
+@@ -514,6 +754,7 @@
  
     public Explosion func_230546_a_(@Nullable Entity p_230546_1_, @Nullable DamageSource p_230546_2_, @Nullable ExplosionContext p_230546_3_, double p_230546_4_, double p_230546_6_, double p_230546_8_, float p_230546_10_, boolean p_230546_11_, Explosion.Mode p_230546_12_) {
        Explosion explosion = new Explosion(this, p_230546_1_, p_230546_2_, p_230546_3_, p_230546_4_, p_230546_6_, p_230546_8_, p_230546_10_, p_230546_11_, p_230546_12_);
@@ -553,7 +552,7 @@
        explosion.func_77278_a();
        explosion.func_77279_a(true);
        return explosion;
-@@ -525,22 +767,34 @@
+@@ -525,22 +766,34 @@
  
     @Nullable
     public TileEntity func_175625_s(BlockPos p_175625_1_) {
@@ -592,7 +591,7 @@
           }
  
           return tileentity;
-@@ -561,7 +815,15 @@
+@@ -561,7 +814,15 @@
  
     public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_) {
        if (!func_189509_E(p_175690_1_)) {
@@ -608,7 +607,7 @@
              if (this.field_147481_N) {
                 p_175690_2_.func_226984_a_(this, p_175690_1_);
                 Iterator<TileEntity> iterator = this.field_147484_a.iterator();
-@@ -576,7 +838,8 @@
+@@ -576,7 +837,8 @@
  
                 this.field_147484_a.add(p_175690_2_);
              } else {
@@ -618,7 +617,7 @@
                 this.func_175700_a(p_175690_2_);
              }
           }
-@@ -585,10 +848,12 @@
+@@ -585,10 +847,12 @@
     }
  
     public void func_175713_t(BlockPos p_175713_1_) {
@@ -632,7 +631,7 @@
        } else {
           if (tileentity != null) {
              this.field_147484_a.remove(tileentity);
-@@ -598,7 +863,7 @@
+@@ -598,7 +862,7 @@
  
           this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
        }
@@ -641,7 +640,7 @@
     }
  
     public boolean func_195588_v(BlockPos p_195588_1_) {
-@@ -651,10 +916,10 @@
+@@ -651,10 +915,10 @@
     public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate<? super Entity> p_175674_3_) {
        this.func_217381_Z().func_230035_c_("getEntities");
        List<Entity> list = Lists.newArrayList();
@@ -656,7 +655,7 @@
        AbstractChunkProvider abstractchunkprovider = this.func_72863_F();
  
        for(int i1 = i; i1 <= j; ++i1) {
-@@ -671,10 +936,10 @@
+@@ -671,10 +935,10 @@
  
     public <T extends Entity> List<T> func_217394_a(@Nullable EntityType<T> p_217394_1_, AxisAlignedBB p_217394_2_, Predicate<? super T> p_217394_3_) {
        this.func_217381_Z().func_230035_c_("getEntities");
@@ -671,7 +670,7 @@
        List<T> list = Lists.newArrayList();
  
        for(int i1 = i; i1 < j; ++i1) {
-@@ -691,10 +956,10 @@
+@@ -691,10 +955,10 @@
  
     public <T extends Entity> List<T> func_175647_a(Class<? extends T> p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate<? super T> p_175647_3_) {
        this.func_217381_Z().func_230035_c_("getEntities");
@@ -686,7 +685,7 @@
        List<T> list = Lists.newArrayList();
        AbstractChunkProvider abstractchunkprovider = this.func_72863_F();
  
-@@ -712,10 +977,10 @@
+@@ -712,10 +976,10 @@
  
     public <T extends Entity> List<T> func_225316_b(Class<? extends T> p_225316_1_, AxisAlignedBB p_225316_2_, @Nullable Predicate<? super T> p_225316_3_) {
        this.func_217381_Z().func_230035_c_("getLoadedEntities");
@@ -701,7 +700,7 @@
        List<T> list = Lists.newArrayList();
        AbstractChunkProvider abstractchunkprovider = this.func_72863_F();
  
-@@ -739,6 +1004,7 @@
+@@ -739,6 +1003,7 @@
           this.func_175726_f(p_175646_1_).func_76630_e();
        }
  
@@ -709,7 +708,7 @@
     }
  
     public int func_181545_F() {
-@@ -783,7 +1049,7 @@
+@@ -783,7 +1048,7 @@
     public int func_175651_c(BlockPos p_175651_1_, Direction p_175651_2_) {
        BlockState blockstate = this.func_180495_p(p_175651_1_);
        int i = blockstate.func_185911_a(this, p_175651_1_, p_175651_2_);
@@ -718,7 +717,7 @@
     }
  
     public boolean func_175640_z(BlockPos p_175640_1_) {
-@@ -938,16 +1204,15 @@
+@@ -938,16 +1203,15 @@
     public abstract Scoreboard func_96441_U();
  
     public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_) {
@@ -739,7 +738,7 @@
                    blockstate.func_215697_a(this, blockpos, p_175666_2_, p_175666_1_, false);
                 }
              }
-@@ -1024,7 +1289,27 @@
+@@ -1024,7 +1288,27 @@
        return this.field_226689_w_;
     }
  

--- a/patches/minecraft/net/minecraft/world/chunk/ChunkSection.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/ChunkSection.java.patch
@@ -51,24 +51,24 @@
        this.field_206918_e = 0;
 -      this.field_177488_d.func_225497_a((p_225496_1_, p_225496_2_) -> {
 +      // Paper start - Optimise random block ticking
-+      this.field_177488_d.forEachLocation((p_225496_1_, p_225496_2_) -> {
++      this.field_177488_d.forEachLocation((p_225496_1_, p_225496_2_, offdata) -> {
           FluidState fluidstate = p_225496_1_.func_204520_s();
           if (!p_225496_1_.func_196958_f()) {
 -            this.field_76682_b = (short)(this.field_76682_b + p_225496_2_);
-+            this.field_76682_b = (short)(this.field_76682_b + 1);
++            this.field_76682_b = (short)(this.field_76682_b + offdata);
              if (p_225496_1_.func_204519_t()) {
 -               this.field_76683_c = (short)(this.field_76683_c + p_225496_2_);
-+               this.field_76683_c = (short)(this.field_76683_c + 1);
++               this.field_76683_c = (short)(this.field_76683_c + offdata);
 +               this.tickableBlocks.add(p_225496_2_, p_225496_1_);
              }
           }
  
           if (!fluidstate.func_206888_e()) {
 -            this.field_76682_b = (short)(this.field_76682_b + p_225496_2_);
-+            this.field_76682_b = (short)(this.field_76682_b + 1);
++            this.field_76682_b = (short)(this.field_76682_b + offdata);
              if (fluidstate.func_206890_h()) {
 -               this.field_206918_e = (short)(this.field_206918_e + p_225496_2_);
-+               this.field_206918_e = (short)(this.field_206918_e + 1);
++               this.field_206918_e = (short)(this.field_206918_e + offdata);
              }
           }
  

--- a/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ServerWorld.java.patch
@@ -277,7 +277,7 @@
           if (this.field_241105_O_ != null) {
              this.field_241105_O_.func_186105_b();
           }
-@@ -351,18 +412,22 @@
+@@ -351,19 +412,24 @@
           this.field_217492_a = true;
           ObjectIterator<Entry<Entity>> objectiterator = this.field_217498_x.int2ObjectEntrySet().iterator();
  
@@ -298,9 +298,11 @@
  
 +                  timings.tickEntities.stopTiming(); // Spigot
                    this.func_217391_K();
++                  this.spigotConfig.currentPrimedTnt = 0; // Mohist - Fix explosions with Performant
                    break label164;
                 }
-@@ -395,7 +460,7 @@
+ 
+@@ -395,7 +461,7 @@
              }
  
              iprofiler.func_76320_a("tick");
@@ -309,7 +311,7 @@
                 this.func_217390_a(this::func_217479_a, entity1);
              }
  
-@@ -404,7 +469,7 @@
+@@ -404,7 +470,7 @@
              if (entity1.field_70128_L) {
                 this.func_217454_n(entity1);
                 objectiterator.remove();
@@ -318,7 +320,7 @@
              }
  
              iprofiler.func_76319_b();
-@@ -443,6 +508,8 @@
+@@ -443,6 +509,8 @@
        });
     }
  
@@ -327,7 +329,7 @@
     public void func_217441_a(Chunk p_217441_1_, int p_217441_2_) {
        ChunkPos chunkpos = p_217441_1_.func_76632_l();
        boolean flag = this.func_72896_J();
-@@ -460,13 +527,13 @@
+@@ -460,13 +528,13 @@
                 skeletonhorseentity.func_190691_p(true);
                 skeletonhorseentity.func_70873_a(0);
                 skeletonhorseentity.func_70107_b((double)blockpos.func_177958_n(), (double)blockpos.func_177956_o(), (double)blockpos.func_177952_p());
@@ -343,7 +345,7 @@
           }
        }
  
-@@ -475,12 +542,13 @@
+@@ -475,12 +543,13 @@
           BlockPos blockpos2 = this.func_205770_a(Heightmap.Type.MOTION_BLOCKING, this.func_217383_a(i, 0, j, 15));
           BlockPos blockpos3 = blockpos2.func_177977_b();
           Biome biome = this.func_226691_t_(blockpos2);
@@ -359,7 +361,7 @@
           }
  
           if (flag && this.func_226691_t_(blockpos3).func_201851_b() == Biome.RainType.RAIN) {
-@@ -488,32 +556,38 @@
+@@ -488,32 +557,38 @@
           }
        }
  
@@ -420,7 +422,7 @@
     }
  
     protected BlockPos func_175736_a(BlockPos p_175736_1_) {
-@@ -544,7 +618,7 @@
+@@ -544,7 +619,7 @@
           int j = 0;
  
           for(ServerPlayerEntity serverplayerentity : this.field_217491_A) {
@@ -429,7 +431,7 @@
                 ++i;
              } else if (serverplayerentity.func_70608_bn()) {
                 ++j;
-@@ -561,10 +635,22 @@
+@@ -561,10 +636,22 @@
     }
  
     private void func_73051_P() {
@@ -454,7 +456,7 @@
     }
  
     public void func_82742_i() {
-@@ -591,6 +677,14 @@
+@@ -591,6 +678,14 @@
        if (!(p_217479_1_ instanceof PlayerEntity) && !this.func_72863_F().func_217204_a(p_217479_1_)) {
           this.func_217464_b(p_217479_1_);
        } else {
@@ -469,7 +471,7 @@
           p_217479_1_.func_226286_f_(p_217479_1_.func_226277_ct_(), p_217479_1_.func_226278_cu_(), p_217479_1_.func_226281_cx_());
           p_217479_1_.field_70126_B = p_217479_1_.field_70177_z;
           p_217479_1_.field_70127_C = p_217479_1_.field_70125_A;
-@@ -598,10 +692,12 @@
+@@ -598,10 +693,12 @@
              ++p_217479_1_.field_70173_aa;
              IProfiler iprofiler = this.func_217381_Z();
              iprofiler.func_194340_a(() -> {
@@ -483,7 +485,7 @@
              iprofiler.func_76319_b();
           }
  
-@@ -611,6 +707,7 @@
+@@ -611,6 +708,7 @@
                 this.func_217459_a(p_217479_1_, entity);
              }
           }
@@ -491,7 +493,7 @@
  
        }
     }
-@@ -629,6 +726,7 @@
+@@ -629,6 +727,7 @@
                 });
                 iprofiler.func_230035_c_("tickPassenger");
                 p_217459_2_.func_70098_U();
@@ -499,7 +501,7 @@
                 iprofiler.func_76319_b();
              }
  
-@@ -649,7 +747,7 @@
+@@ -649,7 +748,7 @@
        if (p_217464_1_.func_233578_ci_()) {
           this.func_217381_Z().func_76320_a("chunkCheck");
           int i = MathHelper.func_76128_c(p_217464_1_.func_226277_ct_() / 16.0D);
@@ -508,7 +510,7 @@
           int k = MathHelper.func_76128_c(p_217464_1_.func_226281_cx_() / 16.0D);
           if (!p_217464_1_.field_70175_ag || p_217464_1_.field_70176_ah != i || p_217464_1_.field_70162_ai != j || p_217464_1_.field_70164_aj != k) {
              if (p_217464_1_.field_70175_ag && this.func_217354_b(p_217464_1_.field_70176_ah, p_217464_1_.field_70164_aj)) {
-@@ -658,7 +756,7 @@
+@@ -658,7 +757,7 @@
  
              if (!p_217464_1_.func_233577_ch_() && !this.func_217354_b(i, k)) {
                 if (p_217464_1_.field_70175_ag) {
@@ -517,7 +519,7 @@
                 }
  
                 p_217464_1_.field_70175_ag = false;
-@@ -678,6 +776,7 @@
+@@ -678,6 +777,7 @@
     public void func_217445_a(@Nullable IProgressUpdate p_217445_1_, boolean p_217445_2_, boolean p_217445_3_) {
        ServerChunkProvider serverchunkprovider = this.func_72863_F();
        if (!p_217445_3_) {
@@ -525,7 +527,7 @@
           if (p_217445_1_ != null) {
              p_217445_1_.func_200210_a(new TranslationTextComponent("menu.savingLevel"));
           }
-@@ -687,6 +786,7 @@
+@@ -687,6 +787,7 @@
              p_217445_1_.func_200209_c(new TranslationTextComponent("menu.savingChunks"));
           }
  
@@ -533,7 +535,7 @@
           serverchunkprovider.func_217210_a(p_217445_2_);
        }
     }
-@@ -743,13 +843,23 @@
+@@ -743,13 +844,23 @@
     }
  
     public boolean func_217376_c(Entity p_217376_1_) {
@@ -559,7 +561,7 @@
     public void func_217460_e(Entity p_217460_1_) {
        boolean flag = p_217460_1_.field_98038_p;
        p_217460_1_.field_98038_p = true;
-@@ -777,9 +887,10 @@
+@@ -777,9 +888,10 @@
     }
  
     private void func_217448_f(ServerPlayerEntity p_217448_1_) {
@@ -571,7 +573,7 @@
           entity.func_213319_R();
           this.func_217434_e((ServerPlayerEntity)entity);
        }
-@@ -795,18 +906,24 @@
+@@ -795,18 +907,24 @@
     }
  
     private boolean func_72838_d(Entity p_72838_1_) {
@@ -602,7 +604,7 @@
              return true;
           }
        }
-@@ -816,6 +933,7 @@
+@@ -816,6 +934,7 @@
        if (this.func_217478_l(p_217440_1_)) {
           return false;
        } else {
@@ -610,7 +612,7 @@
           this.func_217465_m(p_217440_1_);
           return true;
        }
-@@ -827,7 +945,7 @@
+@@ -827,7 +946,7 @@
        if (entity == null) {
           return false;
        } else {
@@ -619,7 +621,7 @@
           return true;
        }
     }
-@@ -851,15 +969,30 @@
+@@ -851,15 +970,30 @@
     }
  
     public boolean func_242106_g(Entity p_242106_1_) {
@@ -652,7 +654,7 @@
        this.field_147483_b.addAll(p_217466_1_.func_177434_r().values());
        ClassInheritanceMultiMap<Entity>[] aclassinheritancemultimap = p_217466_1_.func_177429_s();
        int i = aclassinheritancemultimap.length;
-@@ -879,12 +1012,41 @@
+@@ -879,12 +1013,41 @@
  
     }
  
@@ -695,7 +697,7 @@
  
        this.field_175741_N.remove(p_217484_1_.func_110124_au());
        this.func_72863_F().func_217226_b(p_217484_1_);
-@@ -894,10 +1056,19 @@
+@@ -894,10 +1057,19 @@
        }
  
        this.func_96441_U().func_181140_a(p_217484_1_);
@@ -715,7 +717,7 @@
     }
  
     private void func_217465_m(Entity p_217465_1_) {
-@@ -913,20 +1084,31 @@
+@@ -913,20 +1085,31 @@
  
           this.field_175741_N.put(p_217465_1_.func_110124_au(), p_217465_1_);
           this.func_72863_F().func_217230_c(p_217465_1_);
@@ -748,7 +750,7 @@
        }
     }
  
-@@ -939,17 +1121,47 @@
+@@ -939,17 +1122,47 @@
     }
  
     public void func_217434_e(ServerPlayerEntity p_217434_1_) {
@@ -798,7 +800,7 @@
              if (d0 * d0 + d1 * d1 + d2 * d2 < 1024.0D) {
                 serverplayerentity.field_71135_a.func_147359_a(new SAnimateBlockBreakPacket(p_175715_1_, p_175715_2_, p_175715_3_));
              }
-@@ -959,10 +1171,20 @@
+@@ -959,10 +1172,20 @@
     }
  
     public void func_184148_a(@Nullable PlayerEntity p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_) {
@@ -819,7 +821,7 @@
        this.field_73061_a.func_184103_al().func_148543_a(p_217384_1_, p_217384_2_.func_226277_ct_(), p_217384_2_.func_226278_cu_(), p_217384_2_.func_226281_cx_(), p_217384_5_ > 1.0F ? (double)(16.0F * p_217384_5_) : 16.0D, this.func_234923_W_(), new SSpawnMovingSoundEffectPacket(p_217384_3_, p_217384_4_, p_217384_2_, p_217384_5_, p_217384_6_));
     }
  
-@@ -997,9 +1219,17 @@
+@@ -997,9 +1220,17 @@
     }
  
     public Explosion func_230546_a_(@Nullable Entity p_230546_1_, @Nullable DamageSource p_230546_2_, @Nullable ExplosionContext p_230546_3_, double p_230546_4_, double p_230546_6_, double p_230546_8_, float p_230546_10_, boolean p_230546_11_, Explosion.Mode p_230546_12_) {
@@ -840,7 +842,7 @@
        if (p_230546_12_ == Explosion.Mode.NONE) {
           explosion.func_180342_d();
        }
-@@ -1054,12 +1284,19 @@
+@@ -1054,12 +1285,19 @@
     }
  
     public <T extends IParticleData> int func_195598_a(T p_195598_1_, double p_195598_2_, double p_195598_4_, double p_195598_6_, int p_195598_8_, double p_195598_9_, double p_195598_11_, double p_195598_13_, double p_195598_15_) {
@@ -862,7 +864,7 @@
              ++i;
           }
        }
-@@ -1131,7 +1368,13 @@
+@@ -1131,7 +1369,13 @@
     @Nullable
     public MapData func_217406_a(String p_217406_1_) {
        return this.func_73046_m().func_241755_D_().func_217481_x().func_215753_b(() -> {
@@ -877,7 +879,7 @@
        }, p_217406_1_);
     }
  
-@@ -1333,6 +1576,11 @@
+@@ -1333,6 +1577,11 @@
  
     public void func_230547_a_(BlockPos p_230547_1_, Block p_230547_2_) {
        if (!this.func_234925_Z_()) {
@@ -889,7 +891,7 @@
           this.func_195593_d(p_230547_1_, p_230547_2_);
        }
  
-@@ -1399,15 +1647,44 @@
+@@ -1399,15 +1648,44 @@
     }
  
     public static void func_241121_a_(ServerWorld p_241121_0_) {

--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/entity/CraftEntity.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/entity/CraftEntity.java
@@ -374,6 +374,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
             else if (entity instanceof SpawnerMinecartEntity) { return new CraftMinecartMobSpawner(server, (SpawnerMinecartEntity) entity); }
             else if (entity instanceof MinecartEntity) { return new CraftMinecartRideable(server, (MinecartEntity) entity); }
             else if (entity instanceof CommandBlockMinecartEntity) { return new CraftMinecartCommand(server, (CommandBlockMinecartEntity) entity); }
+            else { return new CraftMinecart(server, (AbstractMinecartEntity) entity); }
         } else if (entity instanceof HangingEntity) {
             if (entity instanceof PaintingEntity) { return new CraftPainting(server, (PaintingEntity) entity); }
             else if (entity instanceof ItemFrameEntity) { return new CraftItemFrame(server, (ItemFrameEntity) entity); }
@@ -393,8 +394,6 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
         else if (entity instanceof ContainerMinecartEntity) { return new CraftCustomMinecartContainer(server, (ContainerMinecartEntity) entity); }
         else {return new CraftCustomEntity(server, entity);}
         // CHECKSTYLE:ON
-
-        throw new AssertionError("Unknown entity " + (entity == null ? null : entity.getClass()));
     }
 
     @Override

--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/entity/CraftMinecart.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/entity/CraftMinecart.java
@@ -7,13 +7,19 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.craftbukkit.v1_16_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R3.block.data.CraftBlockData;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Minecart;
 import org.bukkit.material.MaterialData;
 import org.bukkit.util.Vector;
 
-public abstract class CraftMinecart extends CraftVehicle implements Minecart {
+public class CraftMinecart extends CraftVehicle implements Minecart {
     public CraftMinecart(CraftServer server, AbstractMinecartEntity entity) {
         super(server, entity);
+    }
+
+    @Override
+    public EntityType getType() {
+        return EntityType.MINECART;
     }
 
     @Override

--- a/src/main/java/org/bukkit/craftbukkit/v1_16_R3/event/CraftEventFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_16_R3/event/CraftEventFactory.java
@@ -1297,11 +1297,13 @@ public class CraftEventFactory {
         // If they've got the same item in their hand, it'll need to be updated.
         if (itemInHand != null && itemInHand.getItem() == Items.WRITABLE_BOOK) {
             if (!editBookEvent.isCancelled()) {
-                if (editBookEvent.isSigning()) {
-                    itemInHand.setItem(Items.WRITTEN_BOOK);
-                }
-                CraftMetaBook meta = (CraftMetaBook) editBookEvent.getNewBookMeta();
-                CraftItemStack.setItemMeta(itemInHand, meta);
+                // Mohist start - Fix book signing (#981)
+                ItemStack book = editBookEvent.isSigning() ?
+                    new ItemStack(Items.WRITTEN_BOOK) : new ItemStack(Items.WRITABLE_BOOK);
+                CraftItemStack.setItemMeta(book, editBookEvent.getNewBookMeta());
+                player.inventory.setInventorySlotContents(player.inventory.currentItem, book);
+                player.sendContainerToPlayer(player.container);
+                // Mohist end
             }
         }
 


### PR DESCRIPTION
1. Fix unknown entity crash with IE minecarts
Upon placing any minecart from Immersive Engineering, server would crash. Fixed now.
2. Fix phantom blocks after explosion
Port of Paper random tick block optimizations introduced phantom blocks, fixed too.
3. Fix book signing (#981)
Signed books are now created and given to the player correctly.
4. Fix explosions with Performant
If Performant is installed, it overwrites tickBlockEntities() method, at the end of which Spigot's reset of TNT ticks is located.
As a result TNT ticks weren't reset and TNTs would stop blowing up.
Now tick reset is moved just after tickBlockEntities() invocation.