### PR TITLE
Fix #1047

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -396,7 +396,7 @@
           }
        }
  
-@@ -603,28 +_,47 @@
+@@ -603,78 +_,131 @@
     }
  
     private boolean func_175400_cq() {
@@ -439,6 +439,18 @@
 +      if (this.func_70608_bn()) {
 +         return this; // CraftBukkit - SPIGOT-3154
 +      }
++      PortalInfo portalinfo = teleporter.getPortalInfo(this, server, this::func_241829_a);
++      if (portalinfo == null)
++         return null;
++      // CraftBukkit - start
++      Location enter = this.getBukkitEntity().getLocation();
++      Location exit = (server == null) ? null : new Location(server.getWorld(), portalinfo.field_222505_a.field_72450_a, portalinfo.field_222505_a.field_72448_b, portalinfo.field_222505_a.field_72449_c, portalinfo.field_242960_c, portalinfo.field_242961_d);
++      final PlayerTeleportEvent tpEvent = new PlayerTeleportEvent(this.getBukkitEntity(), enter, exit, cause);
++      Bukkit.getServer().getPluginManager().callEvent(tpEvent);
++      if (tpEvent.isCancelled() || tpEvent.getTo() == null) {
++         return null;
++      }
++      // CraftBukkit end
        this.field_184851_cj = true;
        ServerWorld serverworld = this.func_71121_q();
        RegistryKey<World> registrykey = serverworld.func_234923_W_();
@@ -450,8 +462,9 @@
           if (!this.field_71136_j) {
              this.field_71136_j = true;
              this.field_71135_a.func_147359_a(new SChangeGameStatePacket(SChangeGameStatePacket.field_241768_e_, this.field_192040_cp ? 0.0F : 1.0F));
-@@ -633,48 +_,79 @@
- 
+             this.field_192040_cp = true;
+          }
+-
           return this;
        } else {
 -         IWorldInfo iworldinfo = p_241206_1_.func_72912_H();
@@ -466,7 +479,6 @@
 -         PortalInfo portalinfo = this.func_241829_a(p_241206_1_);
 +         serverworld.removeEntity(this, true); //Forge: the player entity is moved to the new world, NOT cloned. So keep the data alive with no matching invalidate call.
 +         this.revive();
-+         PortalInfo portalinfo = teleporter.getPortalInfo(this, server, this::func_241829_a);
           if (portalinfo != null) {
 +            Entity e = teleporter.placeEntity(this, serverworld, server, this.field_70177_z, spawnPortal -> {//Forge: Start vanilla logic
              serverworld.func_217381_Z().func_76320_a("moving");
@@ -488,13 +500,6 @@
 -            serverworld.func_217381_Z().func_76319_b();
 -            this.func_213846_b(serverworld);
 -            this.field_71134_c.func_73080_a(p_241206_1_);
-+               Location enter = this.getBukkitEntity().getLocation();
-+               Location exit = (server == null) ? null : new Location(server.getWorld(), portalinfo.field_222505_a.field_72450_a, portalinfo.field_222505_a.field_72448_b, portalinfo.field_222505_a.field_72449_c, portalinfo.field_242960_c, portalinfo.field_242961_d);
-+               final PlayerTeleportEvent tpEvent = new PlayerTeleportEvent(this.getBukkitEntity(), enter, exit, cause);
-+               Bukkit.getServer().getPluginManager().callEvent(tpEvent);
-+               if (tpEvent.isCancelled() || tpEvent.getTo() == null) {
-+                  return null;
-+               }
 +               serverworld.func_217381_Z().func_76319_b();
 +               serverworld.func_217381_Z().func_76320_a("placing");
 +               this.func_70029_a(server);


### PR DESCRIPTION
Fixing bukkit teleport event. We need cancel teleport before teleporting, not when entity already teleported and removed from world.