### PR TITLE
Fix setTarget in entity, fix piglins

### DIFF
--- a/patches/minecraft/net/minecraft/entity/MobEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/MobEntity.java.patch
@@ -91,21 +91,17 @@
     }
  
     protected void func_184651_r() {
-@@ -197,7 +_,43 @@
+@@ -197,7 +_,39 @@
     }
  
     public void func_70624_b(@Nullable LivingEntity p_70624_1_) {
 -      this.field_70696_bz = p_70624_1_;
-+      // CraftBukkit start //Mohist - Fix NPE caused by setAttackTarget(null)
-+      if (p_70624_1_ == null) {
-+         this.field_70696_bz = null;
-+         net.minecraftforge.common.ForgeHooks.onLivingSetAttackTarget(this, p_70624_1_);
-+      } else {
-+         this.setGoalTarget(p_70624_1_, EntityTargetEvent.TargetReason.UNKNOWN, true);
-+      }
++      //Craftbukkit start
++      this.setGoalTarget(p_70624_1_, EntityTargetEvent.TargetReason.UNKNOWN, true);
 +   }
 +
-+   public boolean setGoalTarget(LivingEntity entitylivingbaseIn, EntityTargetEvent.TargetReason reason, final boolean fireEvent) {
++   //LivingEntity can be null, more info in org.bukkit.event.entity.EnitityTargetEvent
++   public boolean setGoalTarget(@Nullable LivingEntity entitylivingbaseIn, EntityTargetEvent.TargetReason reason, final boolean fireEvent) {
 +      if (this.func_70638_az() == entitylivingbaseIn) {
 +         return false;
 +      }

--- a/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EndermanEntity.java.patch
@@ -12,35 +12,33 @@
  
  public class EndermanEntity extends MonsterEntity implements IAngerable {
     private static final UUID field_110192_bp = UUID.fromString("020E0DFB-87AE-4653-9556-831010E291A0");
-@@ -98,9 +_,18 @@
+@@ -97,10 +_,13 @@
+       return MonsterEntity.func_234295_eP_().func_233815_a_(Attributes.field_233818_a_, 40.0D).func_233815_a_(Attributes.field_233821_d_, (double)0.3F).func_233815_a_(Attributes.field_233823_f_, 7.0D).func_233815_a_(Attributes.field_233819_b_, 64.0D);
     }
  
-    public void func_70624_b(@Nullable LivingEntity p_70624_1_) {
+-   public void func_70624_b(@Nullable LivingEntity p_70624_1_) {
 -      super.func_70624_b(p_70624_1_);
-+      // CraftBukkit start - fire event
-+      setAttackTarget(p_70624_1_, TargetReason.UNKNOWN, true);
-+   }
-+
-+   public boolean setAttackTarget(@Nullable LivingEntity entitylivingbaseIn, TargetReason reason, boolean fireEvent) {
++   //Craftbukkit start
++   public boolean setGoalTarget(@Nullable LivingEntity entitylivingbaseIn, TargetReason reason, boolean fireEvent) {
 +      if(!super.setGoalTarget(entitylivingbaseIn, reason, fireEvent)){
 +         return false;
 +      }
-+      entitylivingbaseIn = func_70638_az();
-+      // CraftBukkit end
        ModifiableAttributeInstance modifiableattributeinstance = this.func_110148_a(Attributes.field_233821_d_);
 -      if (p_70624_1_ == null) {
 +      if (entitylivingbaseIn == null) {
           this.field_184721_by = 0;
           this.field_70180_af.func_187227_b(field_184719_bw, false);
           this.field_70180_af.func_187227_b(field_226535_bx_, false);
-@@ -113,6 +_,7 @@
+@@ -113,7 +_,9 @@
           }
        }
  
 +      return true; // CraftBukkit
     }
++   // CraftBukkit end
  
     protected void func_70088_a() {
+       super.func_70088_a();
 @@ -181,12 +_,13 @@
        }
  

--- a/patches/minecraft/net/minecraft/entity/monster/piglin/StartAdmiringItemTask.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/piglin/StartAdmiringItemTask.java.patch
@@ -5,7 +5,7 @@
  
     protected boolean func_212832_a_(ServerWorld p_212832_1_, E p_212832_2_) {
 -      return !p_212832_2_.func_184592_cb().func_190926_b() && p_212832_2_.func_184592_cb().func_77973_b() != Items.field_185159_cQ;
-+      return !p_212832_2_.func_184592_cb().func_190926_b() && p_212832_2_.func_184592_cb().isShield(p_212832_2_);
++      return !p_212832_2_.func_184592_cb().func_190926_b() && !p_212832_2_.func_184592_cb().isShield(p_212832_2_);
     }
  
     protected void func_212831_a_(ServerWorld p_212831_1_, E p_212831_2_, long p_212831_3_) {


### PR DESCRIPTION
Fixed piglins (#1076, #1032)
Fixed endermans (#1033, #1064)
Probably fixed something more with entities
**_LivingEntity_** in **_setGoalTarget_** method can be null, if it will throw error in event **_EntityTargetEvent_** - its plugins problem, not core.