### PR TITLE
Adding paper events (75%)

### DIFF
--- a/patches/minecraft/net/minecraft/block/FlowerPotBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FlowerPotBlock.java.patch
@@ -1,6 +1,26 @@
 --- a/net/minecraft/block/FlowerPotBlock.java
 +++ b/net/minecraft/block/FlowerPotBlock.java
-@@ -24,10 +_,33 @@
+@@ -2,7 +_,11 @@
+ 
+ import com.google.common.collect.Maps;
+ import java.util.Map;
++
++import io.papermc.paper.event.player.PlayerFlowerPotManipulateEvent;
++import net.minecraft.client.entity.player.AbstractClientPlayerEntity;
+ import net.minecraft.entity.player.PlayerEntity;
++import net.minecraft.entity.player.ServerPlayerEntity;
+ import net.minecraft.item.BlockItem;
+ import net.minecraft.item.Item;
+ import net.minecraft.item.ItemStack;
+@@ -18,16 +_,41 @@
+ import net.minecraft.world.IBlockReader;
+ import net.minecraft.world.IWorld;
+ import net.minecraft.world.World;
++import org.bukkit.Bukkit;
++import org.bukkit.craftbukkit.v1_16_R3.entity.CraftPlayer;
+ 
+ public class FlowerPotBlock extends Block {
+    private static final Map<Block, Block> field_196451_b = Maps.newHashMap();
     protected static final VoxelShape field_196450_a = Block.func_208617_a(5.0D, 0.0D, 5.0D, 11.0D, 6.0D, 11.0D);
     private final Block field_196452_c;
  
@@ -37,7 +57,7 @@
     }
  
     public VoxelShape func_220053_a(BlockState p_220053_1_, IBlockReader p_220053_2_, BlockPos p_220053_3_, ISelectionContext p_220053_4_) {
-@@ -41,7 +_,7 @@
+@@ -41,10 +_,29 @@
     public ActionResultType func_225533_a_(BlockState p_225533_1_, World p_225533_2_, BlockPos p_225533_3_, PlayerEntity p_225533_4_, Hand p_225533_5_, BlockRayTraceResult p_225533_6_) {
        ItemStack itemstack = p_225533_4_.func_184586_b(p_225533_5_);
        Item item = itemstack.func_77973_b();
@@ -46,6 +66,28 @@
        boolean flag = block == Blocks.field_150350_a;
        boolean flag1 = this.field_196452_c == Blocks.field_150350_a;
        if (flag != flag1) {
++         // Paper start
++         org.bukkit.entity.Player bukkitPlayer = (org.bukkit.entity.Player) p_225533_4_.getBukkitEntity();
++         org.bukkit.block.Block bukkitBlock = org.bukkit.craftbukkit.v1_16_R3.block.CraftBlock.at(p_225533_2_, p_225533_3_);
++         org.bukkit.inventory.ItemStack bukkitStack = org.bukkit.craftbukkit.v1_16_R3.inventory.CraftItemStack.asBukkitCopy(itemstack);
++         org.bukkit.Material bukkitMat = org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers.getMaterial(field_196452_c);
++         org.bukkit.inventory.ItemStack bukkitStack1 = new org.bukkit.inventory.ItemStack(bukkitMat, 1);
++         org.bukkit.inventory.ItemStack whichitem = flag1 ? bukkitStack : bukkitStack1;
++
++         PlayerFlowerPotManipulateEvent event = new PlayerFlowerPotManipulateEvent(bukkitPlayer, bukkitBlock, whichitem, flag1);
++         Bukkit.getServer().getPluginManager().callEvent(event);
++
++         if (event.isCancelled()) {
++            bukkitPlayer.sendBlockChange(bukkitBlock.getLocation(), bukkitBlock.getBlockData());
++            bukkitPlayer.updateInventory();
++
++            return ActionResultType.PASS;
++         }
++         // Paper end
++
+          if (flag1) {
+             p_225533_2_.func_180501_a(p_225533_3_, block.func_176223_P(), 3);
+             p_225533_4_.func_195066_a(Stats.field_188088_V);
 @@ -59,7 +_,7 @@
                 p_225533_4_.func_71019_a(itemstack1, false);
              }

--- a/patches/minecraft/net/minecraft/entity/merchant/villager/AbstractVillagerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/merchant/villager/AbstractVillagerEntity.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/entity/merchant/villager/AbstractVillagerEntity.java
 +++ b/net/minecraft/entity/merchant/villager/AbstractVillagerEntity.java
+@@ -3,6 +_,8 @@
+ import com.google.common.collect.Sets;
+ import java.util.Set;
+ import javax.annotation.Nullable;
++
++import io.papermc.paper.event.player.PlayerTradeEvent;
+ import net.minecraft.advancements.CriteriaTriggers;
+ import net.minecraft.entity.AgeableEntity;
+ import net.minecraft.entity.Entity;
 @@ -36,14 +_,29 @@
  import net.minecraft.world.server.ServerWorld;
  import net.minecraftforge.api.distmarker.Dist;
@@ -31,6 +40,46 @@
  
     public AbstractVillagerEntity(EntityType<? extends AbstractVillagerEntity> p_i50185_1_, World p_i50185_2_) {
        super(p_i50185_1_, p_i50185_2_);
+@@ -110,11 +_,35 @@
+    }
+ 
+    public void func_213704_a(MerchantOffer p_213704_1_) {
+-      p_213704_1_.func_222219_j();
+-      this.field_70757_a = -this.func_70627_aG();
+-      this.func_213713_b(p_213704_1_);
++      //p_213704_1_.increaseUses();
++      //this.ambientSoundTime = -this.getAmbientSoundInterval();
++      //this.rewardTradeXp(p_213704_1_);
++      // Paper start
+       if (this.field_213725_bA instanceof ServerPlayerEntity) {
+-         CriteriaTriggers.field_192138_r.func_215114_a((ServerPlayerEntity)this.field_213725_bA, this, p_213704_1_.func_222200_d());
++         //CriteriaTriggers.TRADE.trigger((ServerPlayerEntity)this.tradingPlayer, this, p_213704_1_.getResult());
++         PlayerTradeEvent event = new PlayerTradeEvent(
++                 ((ServerPlayerEntity) this.field_213725_bA).getBukkitEntity(),
++                 (AbstractVillager) this.getBukkitEntity(),
++                 p_213704_1_.asBukkit(),
++                 true,
++                 true
++         );
++         Bukkit.getServer().getPluginManager().callEvent(event);
++         if (!event.isCancelled()) {
++            MerchantOffer offer = CraftMerchantRecipe.fromBukkit(event.getTrade()).toMinecraft();
++            if (event.willIncreaseTradeUses()) {
++               offer.func_222219_j();
++            }
++            this.field_70757_a = -this.func_70627_aG();
++            if (event.isRewardingExp()) {
++               this.func_213713_b(offer);
++            }
++            CriteriaTriggers.field_192138_r.func_215114_a((ServerPlayerEntity)this.field_213725_bA, this, offer.func_222200_d());
++         }
++      } else {
++         p_213704_1_.func_222219_j();
++         this.field_70757_a = -this.func_70627_aG();
++         this.func_213713_b(p_213704_1_);
+       }
+ 
+    }
 @@ -165,9 +_,9 @@
     }
  

--- a/patches/minecraft/net/minecraft/inventory/container/BeaconContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/BeaconContainer.java.patch
@@ -1,17 +1,22 @@
 --- a/net/minecraft/inventory/container/BeaconContainer.java
 +++ b/net/minecraft/inventory/container/BeaconContainer.java
-@@ -3,6 +_,7 @@
+@@ -1,8 +_,11 @@
+ package net.minecraft.inventory.container;
+ 
  import javax.annotation.Nullable;
++
++import io.papermc.paper.event.player.PlayerChangeBeaconEffectEvent;
  import net.minecraft.block.Blocks;
  import net.minecraft.entity.player.PlayerEntity;
 +import net.minecraft.entity.player.PlayerInventory;
  import net.minecraft.inventory.IInventory;
  import net.minecraft.inventory.Inventory;
  import net.minecraft.item.ItemStack;
-@@ -13,6 +_,9 @@
+@@ -13,6 +_,10 @@
  import net.minecraft.util.IntArray;
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
++import org.bukkit.Bukkit;
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryBeacon;
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryView;
@@ -78,3 +83,29 @@
           } else if (p_82846_2_ >= 1 && p_82846_2_ < 28) {
              if (!this.func_75135_a(itemstack1, 28, 37, false)) {
                 return ItemStack.field_190927_a;
+@@ -138,9 +_,22 @@
+ 
+    public void func_216966_c(int p_216966_1_, int p_216966_2_) {
+       if (this.field_82864_f.func_75216_d()) {
+-         this.field_216972_f.func_221477_a(1, p_216966_1_);
+-         this.field_216972_f.func_221477_a(2, p_216966_2_);
+-         this.field_82864_f.func_75209_a(1);
++         // Paper start
++         PlayerChangeBeaconEffectEvent event = new PlayerChangeBeaconEffectEvent(
++                 (org.bukkit.entity.Player) this.player.field_70458_d.getBukkitEntity(),
++                 org.bukkit.potion.PotionEffectType.getById(p_216966_1_),
++                 org.bukkit.potion.PotionEffectType.getById(p_216966_2_),
++                 this.field_82866_e.getLocation().getBlock()
++         );
++         Bukkit.getServer().getPluginManager().callEvent(event);
++         if (!event.isCancelled()) {
++            this.field_216972_f.func_221477_a(1, event.getPrimary() == null ? 0 : event.getPrimary().getId());
++            this.field_216972_f.func_221477_a(2, event.getSecondary() == null ? 0 : event.getSecondary().getId());
++            if (event.willConsumeItem()) {
++               this.field_82864_f.func_75209_a(1);
++            }
++         }
++         // Paper end
+       }
+ 
+    }

--- a/patches/minecraft/net/minecraft/inventory/container/LecternContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/LecternContainer.java.patch
@@ -1,8 +1,9 @@
 --- a/net/minecraft/inventory/container/LecternContainer.java
 +++ b/net/minecraft/inventory/container/LecternContainer.java
-@@ -1,6 +_,7 @@
+@@ -1,6 +_,8 @@
  package net.minecraft.inventory.container;
  
++import io.papermc.paper.event.player.PlayerLecternPageChangeEvent;
  import net.minecraft.entity.player.PlayerEntity;
 +import net.minecraft.entity.player.PlayerInventory;
  import net.minecraft.inventory.IInventory;
@@ -52,7 +53,7 @@
        func_216962_a(p_i50076_2_, 1);
        func_216959_a(p_i50076_3_, 1);
        this.field_217018_c = p_i50076_2_;
-@@ -30,6 +_,7 @@
+@@ -30,9 +_,12 @@
           }
        });
        this.func_216961_a(p_i50076_3_);
@@ -60,7 +61,57 @@
     }
  
     public boolean func_75140_a(PlayerEntity p_75140_1_, int p_75140_2_) {
-@@ -52,6 +_,14 @@
++      PlayerLecternPageChangeEvent paper_event;
++      CraftInventoryLectern bukkitLectern;
+       if (p_75140_2_ >= 100) {
+          int k = p_75140_2_ - 100;
+          this.func_75137_b(0, k);
+@@ -41,17 +_,57 @@
+          switch(p_75140_2_) {
+          case 1:
+             int j = this.field_217019_d.func_221476_a(0);
+-            this.func_75137_b(0, j - 1);
++            //this.setData(0, j - 1);
++            // Paper start
++            bukkitLectern = (CraftInventoryLectern) getBukkitView().getTopInventory();
++            paper_event = new PlayerLecternPageChangeEvent(
++                    (org.bukkit.entity.Player) p_75140_1_.getBukkitEntity(),
++                    bukkitLectern.getHolder(),
++                    bukkitLectern.getItem(0),
++                    PlayerLecternPageChangeEvent.PageChangeDirection.LEFT,
++                    j,
++                    j - 1
++            );
++            Bukkit.getServer().getPluginManager().callEvent(paper_event);
++            if (paper_event.isCancelled()) {
++               return false;
++            }
++            this.func_75137_b(0, paper_event.getNewPage());
++            // Paper end
+             return true;
+          case 2:
+             int i = this.field_217019_d.func_221476_a(0);
+-            this.func_75137_b(0, i + 1);
++            //this.setData(0, i + 1);
++            // Paper start
++            bukkitLectern = (CraftInventoryLectern) getBukkitView().getTopInventory();
++            paper_event = new PlayerLecternPageChangeEvent(
++                    (org.bukkit.entity.Player) p_75140_1_.getBukkitEntity(),
++                    bukkitLectern.getHolder(),
++                    bukkitLectern.getItem(0),
++                    PlayerLecternPageChangeEvent.PageChangeDirection.RIGHT,
++                    i,
++                    i + 1
++            );
++            Bukkit.getServer().getPluginManager().callEvent(paper_event);
++            if (paper_event.isCancelled()) {
++               return false;
++            }
++            this.func_75137_b(0, paper_event.getNewPage());
++            // Paper end
+             return true;
+          case 3:
+             if (!p_75140_1_.func_175142_cm()) {
                 return false;
              }
  

--- a/patches/minecraft/net/minecraft/inventory/container/LoomContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/LoomContainer.java.patch
@@ -1,9 +1,17 @@
 --- a/net/minecraft/inventory/container/LoomContainer.java
 +++ b/net/minecraft/inventory/container/LoomContainer.java
-@@ -19,8 +_,28 @@
+@@ -1,5 +_,6 @@
+ package net.minecraft.inventory.container;
+ 
++import io.papermc.paper.event.player.PlayerLoomPatternSelectEvent;
+ import net.minecraft.block.Blocks;
+ import net.minecraft.entity.player.PlayerEntity;
+ import net.minecraft.entity.player.PlayerInventory;
+@@ -19,8 +_,29 @@
  import net.minecraft.util.SoundEvents;
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
++import org.bukkit.Bukkit;
 +import org.bukkit.Location;
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryLoom;
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryView;
@@ -62,7 +70,7 @@
     }
  
     @OnlyIn(Dist.CLIENT)
-@@ -109,6 +_,7 @@
+@@ -109,12 +_,35 @@
     }
  
     public boolean func_75145_c(PlayerEntity p_75145_1_) {
@@ -70,6 +78,35 @@
        return func_216963_a(this.field_217033_c, p_75145_1_, Blocks.field_222421_lJ);
     }
  
+    public boolean func_75140_a(PlayerEntity p_75140_1_, int p_75140_2_) {
+       if (p_75140_2_ > 0 && p_75140_2_ <= BannerPattern.field_222481_P) {
+-         this.field_217034_d.func_221494_a(p_75140_2_);
++         //this.selectedBannerPatternIndex.set(p_75140_2_);
++         // Paper start
++         int ordinal = p_75140_2_;
++         PlayerLoomPatternSelectEvent event = new PlayerLoomPatternSelectEvent(
++                 (Player) p_75140_1_.getBukkitEntity(),
++                 (CraftInventoryLoom) getBukkitView().getTopInventory(),
++                 org.bukkit.block.banner.PatternType.getByIdentifier(
++                         BannerPattern.values()[p_75140_2_].func_190993_b())
++         );
++         Bukkit.getServer().getPluginManager().callEvent(event);
++         if (event.isCancelled()) {
++            ((Player) p_75140_1_.getBukkitEntity()).updateInventory();
++            return false;
++         }
++         for (BannerPattern nms : BannerPattern.values()) {
++            if (event.getPatternType().getIdentifier().equals(nms.func_190993_b())) {
++               ordinal = nms.ordinal();
++               break;
++            }
++         }
++         ((Player) p_75140_1_.getBukkitEntity()).updateInventory();
++         this.field_217034_d.func_221494_a(ordinal);
++         // Paper end
+          this.func_217031_j();
+          return true;
+       } else {
 @@ -224,6 +_,11 @@
              ListNBT listnbt;
              if (compoundnbt.func_150297_b("Patterns", 9)) {

--- a/patches/minecraft/net/minecraft/inventory/container/StonecutterContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/StonecutterContainer.java.patch
@@ -1,9 +1,19 @@
 --- a/net/minecraft/inventory/container/StonecutterContainer.java
 +++ b/net/minecraft/inventory/container/StonecutterContainer.java
-@@ -19,6 +_,10 @@
+@@ -2,6 +_,8 @@
+ 
+ import com.google.common.collect.Lists;
+ import java.util.List;
++
++import io.papermc.paper.event.player.PlayerStonecutterRecipeSelectEvent;
+ import net.minecraft.block.Blocks;
+ import net.minecraft.entity.player.PlayerEntity;
+ import net.minecraft.entity.player.PlayerInventory;
+@@ -19,10 +_,16 @@
  import net.minecraft.world.World;
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
++import org.bukkit.Bukkit;
 +import org.bukkit.Location;
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryStonecutter;
 +import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryView;
@@ -11,6 +21,12 @@
  
  public class StonecutterContainer extends Container {
     private final IWorldPosCallable field_217088_g;
+-   private final IntReferenceHolder field_217089_h = IntReferenceHolder.func_221492_a();
++   //private final IntReferenceHolder selectedRecipeIndex = IntReferenceHolder.standalone();
++   private final IntReferenceHolder field_217089_h;
+    private final World field_217090_i;
+    private List<StonecuttingRecipe> field_217091_j = Lists.newArrayList();
+    private ItemStack field_217092_k = ItemStack.field_190927_a;
 @@ -37,9 +_,31 @@
           StonecutterContainer.this.func_75130_a(this);
           StonecutterContainer.this.field_217094_m.run();
@@ -43,6 +59,14 @@
     public StonecutterContainer(int p_i50059_1_, PlayerInventory p_i50059_2_) {
        this(p_i50059_1_, p_i50059_2_, IWorldPosCallable.field_221489_a);
     }
+@@ -47,6 +_,7 @@
+    public StonecutterContainer(int p_i50060_1_, PlayerInventory p_i50060_2_, final IWorldPosCallable p_i50060_3_) {
+       super(ContainerType.field_221529_w, p_i50060_1_);
+       this.field_217088_g = p_i50060_3_;
++      field_217089_h = this.func_216958_a(IntReferenceHolder.func_221497_a(new int[1], 0)); // Paper - allow replication
+       this.field_217090_i = p_i50060_2_.field_70458_d.field_70170_p;
+       this.field_217085_d = this.func_75146_a(new Slot(this.field_217087_f, 0, 20, 33));
+       this.field_217086_e = this.func_75146_a(new Slot(this.field_217095_n, 1, 143, 33) {
 @@ -85,6 +_,7 @@
        }
  
@@ -51,11 +75,48 @@
     }
  
     @OnlyIn(Dist.CLIENT)
-@@ -108,6 +_,7 @@
+@@ -108,12 +_,43 @@
     }
  
     public boolean func_75145_c(PlayerEntity p_75145_1_) {
 +      if (!this.checkReachable) return true; // CraftBukkit
        return func_216963_a(this.field_217088_g, p_75145_1_, Blocks.field_222430_lS);
     }
+ 
+    public boolean func_75140_a(PlayerEntity p_75140_1_, int p_75140_2_) {
+       if (this.func_241818_d_(p_75140_2_)) {
+-         this.field_217089_h.func_221494_a(p_75140_2_);
++         // Paper start
++         int recipeIndex = p_75140_2_;
++         this.field_217089_h.func_221494_a(recipeIndex);
++         this.field_217089_h.func_221496_c();
++         if (this.func_241818_d_(p_75140_2_)) {
++            PlayerStonecutterRecipeSelectEvent event = new PlayerStonecutterRecipeSelectEvent(
++                    (org.bukkit.entity.Player) p_75140_1_.getBukkitEntity(),
++                    (org.bukkit.inventory.StonecutterInventory) getBukkitView().getTopInventory(),
++                    (org.bukkit.inventory.StonecuttingRecipe) this.func_217076_f().get(p_75140_2_).toBukkitRecipe()
++            );
++            Bukkit.getServer().getPluginManager().callEvent(event);
++            if (event.isCancelled()) {
++               ((org.bukkit.entity.Player) p_75140_1_.getBukkitEntity()).updateInventory();
++               return false;
++            }
++            if (!this.func_217076_f().get(p_75140_2_).func_199560_c().equals(
++                    org.bukkit.craftbukkit.v1_16_R3.util.CraftNamespacedKey.toMinecraft(
++                            event.getStonecuttingRecipe().getKey()))) { // If the recipe did NOT stay the same
++                  for (int index = 0; index < this.func_217076_f().size(); index++) {
++                     if (this.func_217076_f().get(index).func_199560_c().equals(
++                             org.bukkit.craftbukkit.v1_16_R3.util.CraftNamespacedKey.toMinecraft(
++                                     event.getStonecuttingRecipe().getKey()))) {
++                        recipeIndex = index;
++                        break;
++                     }
++                  }
++            }
++         }
++         ((org.bukkit.entity.Player) p_75140_1_.getBukkitEntity()).updateInventory();
++         this.field_217089_h.func_221494_a(recipeIndex); // set new index, so that listeners can read it
++         // Paper end
+          this.func_217082_i();
+       }
  

--- a/patches/minecraft/net/minecraft/util/ServerCooldownTracker.java.patch
+++ b/patches/minecraft/net/minecraft/util/ServerCooldownTracker.java.patch
@@ -1,0 +1,35 @@
+--- a/net/minecraft/util/ServerCooldownTracker.java
++++ b/net/minecraft/util/ServerCooldownTracker.java
+@@ -1,8 +_,10 @@
+ package net.minecraft.util;
+ 
++import io.papermc.paper.event.player.PlayerItemCooldownEvent;
+ import net.minecraft.entity.player.ServerPlayerEntity;
+ import net.minecraft.item.Item;
+ import net.minecraft.network.play.server.SCooldownPacket;
++import org.bukkit.Bukkit;
+ 
+ public class ServerCooldownTracker extends CooldownTracker {
+    private final ServerPlayerEntity field_185149_a;
+@@ -15,6 +_,21 @@
+       super.func_185140_b(p_185140_1_, p_185140_2_);
+       this.field_185149_a.field_71135_a.func_147359_a(new SCooldownPacket(p_185140_1_, p_185140_2_));
+    }
++
++   // Paper start
++   @Override
++   public void func_185145_a(Item p_185145_1_, int p_185145_2_) {
++      PlayerItemCooldownEvent event = new PlayerItemCooldownEvent(
++              field_185149_a.getBukkitEntity(),
++              org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers.getMaterial(p_185145_1_),
++              p_185145_2_
++      );
++      Bukkit.getServer().getPluginManager().callEvent(event);
++      if (!event.isCancelled()) {
++         super.func_185145_a(p_185145_1_, p_185145_2_);
++      }
++   }
++   // Paper end
+ 
+    protected void func_185146_c(Item p_185146_1_) {
+       super.func_185146_c(p_185146_1_);

--- a/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java
+++ b/src/main/java/io/papermc/paper/event/player/PlayerChangeBeaconEffectEvent.java
@@ -1,0 +1,141 @@
+package io.papermc.paper.event.player;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Called when a player sets the effect for a beacon
+ */
+public class PlayerChangeBeaconEffectEvent extends PlayerEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private PotionEffectType primary;
+    private PotionEffectType secondary;
+    private final Block beacon;
+    private boolean consumeItem = true;
+
+    private boolean isCancelled;
+
+    public PlayerChangeBeaconEffectEvent(@NotNull Player player, @Nullable PotionEffectType primary, @Nullable PotionEffectType secondary, @Nullable Block beacon) {
+        super(player);
+        this.primary = primary;
+        this.secondary = secondary;
+        this.isCancelled = false;
+        this.beacon = beacon;
+    }
+
+    /**
+     * @return the primary effect
+     */
+    @Nullable public PotionEffectType getPrimary() {
+        return primary;
+    }
+
+    /**
+     * Sets the primary effect
+     * <p>
+     * NOTE: The primary effect still has to be one of the valid effects for a beacon.
+     *
+     * @param primary the primary effect
+     */
+    public void setPrimary(@Nullable PotionEffectType primary) {
+        this.primary = primary;
+    }
+
+    /**
+     * @return the secondary effect
+     */
+    @Nullable public PotionEffectType getSecondary() {
+        return secondary;
+    }
+
+    /**
+     * Sets the secondary effect
+     * <p>
+     * This only has an effect when the beacon is able to accept a secondary effect.
+     * NOTE: The secondary effect still has to be a valid effect for a beacon.
+     *
+     * @param secondary the secondary effect
+     */
+    public void setSecondary(@Nullable PotionEffectType secondary) {
+        this.secondary = secondary;
+    }
+
+    /**
+     * @return the beacon block associated with this event, or null if not found
+     */
+    @Nullable
+    public Block getBeacon() {
+        return beacon;
+    }
+
+    /**
+     * Gets if the item used to change the beacon will be consume.
+     * <p>
+     * Independant of {@link #isCancelled()}. If the event is cancelled
+     * the item will <b>NOT</b> be consumed.
+     *
+     * @return true if item will be consumed
+     */
+    public boolean willConsumeItem() {
+        return consumeItem;
+    }
+
+    /**
+     * Sets if the item used to change the beacon should be consumed.
+     * <p>
+     * Independant of {@link #isCancelled()}. If the event is cancelled
+     * the item will <b>NOT</b> be consumed.
+     *
+     * @param consumeItem true if item should be consumed
+     */
+    public void setConsumeItem(boolean consumeItem) {
+        this.consumeItem = consumeItem;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     * <p>
+     * If a {@link PlayerChangeBeaconEffectEvent} is cancelled, the changes will
+     * not take effect
+     *
+     * @return true if this event is cancelled
+     */
+    @Override
+    public boolean isCancelled() {
+        return this.isCancelled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     * <p>
+     * If cancelled, the item will <b>NOT</b> be consumed regardless of what {@link #willConsumeItem()} says
+     * <p>
+     * If a {@link PlayerChangeBeaconEffectEvent} is cancelled, the changes will not be applied
+     * or saved.
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.isCancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/io/papermc/paper/event/player/PlayerFlowerPotManipulateEvent.java
+++ b/src/main/java/io/papermc/paper/event/player/PlayerFlowerPotManipulateEvent.java
@@ -1,0 +1,82 @@
+package io.papermc.paper.event.player;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player places an item in or takes an item out of a flowerpot.
+ */
+public class PlayerFlowerPotManipulateEvent extends PlayerEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    @NotNull
+    private final Block flowerpot;
+    @NotNull
+    private final ItemStack item;
+    private final boolean placing;
+
+    private boolean cancel = false;
+
+    public PlayerFlowerPotManipulateEvent(@NotNull final Player player, @NotNull final Block flowerpot, @NotNull final ItemStack item, final boolean placing) {
+        super(player);
+        this.flowerpot = flowerpot;
+        this.item = item;
+        this.placing = placing;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
+    }
+
+    /**
+     * Gets the flowerpot that is involved in this event.
+     *
+     * @return the flowerpot that is involved with this event
+     */
+    @NotNull
+    public Block getFlowerpot() {
+        return flowerpot;
+    }
+
+    /**
+     * Gets the item being placed, or taken from, the flower pot.
+     * Check if placing with {@link #isPlacing()}.
+     *
+     * @return the item placed, or taken from, the flowerpot
+     */
+    @NotNull
+    public ItemStack getItem() {
+        return item;
+    }
+
+    /**
+     * Gets if the item is being placed into the flowerpot.
+     *
+     * @return if the item is being placed into the flowerpot
+     */
+    public boolean isPlacing() {
+        return placing;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/io/papermc/paper/event/player/PlayerItemCooldownEvent.java
+++ b/src/main/java/io/papermc/paper/event/player/PlayerItemCooldownEvent.java
@@ -1,0 +1,77 @@
+package io.papermc.paper.event.player;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Fired when a player receives an item cooldown.
+ */
+public class PlayerItemCooldownEvent extends PlayerEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    @NotNull
+    private final Material type;
+    private boolean cancelled;
+    private int cooldown;
+
+    public PlayerItemCooldownEvent(@NotNull Player player, @NotNull Material type, int cooldown) {
+        super(player);
+        this.type = type;
+        this.cooldown = cooldown;
+    }
+
+    /**
+     * Get the material affected by the cooldown.
+     *
+     * @return material affected by the cooldown
+     */
+    @NotNull
+    public Material getType() {
+        return type;
+    }
+
+    /**
+     * Gets the cooldown in ticks.
+     *
+     * @return cooldown in ticks
+     */
+    public int getCooldown() {
+        return cooldown;
+    }
+
+    /**
+     * Sets the cooldown of the material in ticks.
+     * Setting the cooldown to 0 results in removing an already existing cooldown for the material.
+     *
+     * @param cooldown cooldown in ticks, has to be a positive number
+     */
+    public void setCooldown(int cooldown) {
+        Preconditions.checkArgument(cooldown >= 0, "The cooldown has to be equal to or greater than 0!");
+        this.cooldown = cooldown;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/io/papermc/paper/event/player/PlayerLecternPageChangeEvent.java
+++ b/src/main/java/io/papermc/paper/event/player/PlayerLecternPageChangeEvent.java
@@ -1,0 +1,115 @@
+package io.papermc.paper.event.player;
+
+import org.bukkit.block.Lectern;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PlayerLecternPageChangeEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private boolean cancelled;
+    private final Lectern lectern;
+    private final ItemStack book;
+    private final PageChangeDirection pageChangeDirection;
+    private final int oldPage;
+    private int newPage;
+
+    public PlayerLecternPageChangeEvent(@NotNull Player player, @NotNull Lectern lectern, @NotNull ItemStack book, @NotNull PageChangeDirection pageChangeDirection, int oldPage, int newPage) {
+        super(player);
+        this.lectern = lectern;
+        this.book = book;
+        this.pageChangeDirection = pageChangeDirection;
+        this.oldPage = oldPage;
+        this.newPage = newPage;
+    }
+
+    /**
+     * Gets the lectern involved.
+     *
+     * @return the Lectern
+     */
+    @NotNull
+    public Lectern getLectern() {
+        return lectern;
+    }
+
+    /**
+     * Gets the current ItemStack on the lectern.
+     *
+     * @return the ItemStack on the Lectern
+     */
+    @NotNull
+    public ItemStack getBook() {
+        return this.book;
+    }
+
+    /**
+     * Gets the page change direction. This is essentially returns which button the player clicked, left or right.
+     *
+     * @return the page change direction
+     */
+    @NotNull
+    public PageChangeDirection getPageChangeDirection() {
+        return pageChangeDirection;
+    }
+
+    /**
+     * Gets the page changed from. <i>Pages are 0-indexed.</i>
+     *
+     * @return the page changed from
+     */
+    public int getOldPage() {
+        return oldPage;
+    }
+
+    /**
+     * Gets the page changed to. <i>Pages are 0-indexed.</i>
+     *
+     * @return the page changed to
+     */
+    public int getNewPage() {
+        return newPage;
+    }
+
+    /**
+     * Sets the page changed to. <i>Pages are 0-indexed.</i>
+     * Page indices that are greater than the number of pages will show the last page.
+     *
+     * @param newPage the new paged changed to
+     */
+    public void setNewPage(int newPage) {
+        this.newPage = newPage;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+
+    public enum PageChangeDirection {
+        LEFT,
+        RIGHT,
+    }
+}

--- a/src/main/java/io/papermc/paper/event/player/PlayerLoomPatternSelectEvent.java
+++ b/src/main/java/io/papermc/paper/event/player/PlayerLoomPatternSelectEvent.java
@@ -1,0 +1,77 @@
+package io.papermc.paper.event.player;
+
+import org.bukkit.block.banner.PatternType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.LoomInventory;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player selects a banner patten in a loom inventory.
+ */
+public class PlayerLoomPatternSelectEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private boolean cancelled;
+    private final LoomInventory loomInventory;
+    private PatternType patternType;
+
+    public PlayerLoomPatternSelectEvent(@NotNull Player player, @NotNull LoomInventory loomInventory, @NotNull PatternType patternType) {
+        super(player);
+        this.loomInventory = loomInventory;
+        this.patternType = patternType;
+    }
+
+    /**
+     * Gets the loom inventory involved.
+     *
+     * @return the loom inventory
+     */
+    @NotNull
+    public LoomInventory getLoomInventory() {
+        return loomInventory;
+    }
+
+    /**
+     * Gets the pattern type selected.
+     *
+     * @return the pattern type
+     */
+    @NotNull
+    public PatternType getPatternType() {
+        return patternType;
+    }
+
+    /**
+     * Sets the pattern type selected.
+     *
+     * @param patternType the pattern type
+     */
+    public void setPatternType(@NotNull PatternType patternType) {
+        this.patternType = patternType;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/src/main/java/io/papermc/paper/event/player/PlayerStonecutterRecipeSelectEvent.java
+++ b/src/main/java/io/papermc/paper/event/player/PlayerStonecutterRecipeSelectEvent.java
@@ -1,0 +1,59 @@
+package io.papermc.paper.event.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.StonecutterInventory;
+import org.bukkit.inventory.StonecuttingRecipe;
+import org.jetbrains.annotations.NotNull;
+
+public class PlayerStonecutterRecipeSelectEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private boolean cancelled;
+    private final StonecutterInventory stonecutterInventory;
+    private StonecuttingRecipe stonecuttingRecipe;
+
+    public PlayerStonecutterRecipeSelectEvent(@NotNull Player player, @NotNull StonecutterInventory stonecutterInventory, @NotNull StonecuttingRecipe stonecuttingRecipe) {
+        super(player);
+        this.stonecutterInventory = stonecutterInventory;
+        this.stonecuttingRecipe = stonecuttingRecipe;
+    }
+
+    @NotNull
+    public StonecutterInventory getStonecutterInventory() {
+        return stonecutterInventory;
+    }
+
+    @NotNull
+    public StonecuttingRecipe getStonecuttingRecipe() {
+        return stonecuttingRecipe;
+    }
+
+    public void setStonecuttingRecipe(@NotNull StonecuttingRecipe stonecuttingRecipe) {
+        this.stonecuttingRecipe = stonecuttingRecipe;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java
+++ b/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java
@@ -1,0 +1,121 @@
+package io.papermc.paper.event.player;
+
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.inventory.MerchantRecipe;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Called when a player trades with a villager or wandering trader
+ */
+public class PlayerTradeEvent extends PlayerEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled;
+
+    private boolean increaseTradeUses;
+    private boolean rewardExp;
+    private final AbstractVillager villager;
+    private MerchantRecipe trade;
+
+    public PlayerTradeEvent(@NotNull Player player, @NotNull AbstractVillager villager, @NotNull MerchantRecipe trade, boolean rewardExp, boolean increaseTradeUses) {
+        super(player);
+        this.villager = villager;
+        this.trade = trade;
+        this.rewardExp = rewardExp;
+        this.increaseTradeUses = increaseTradeUses;
+    }
+
+    /**
+     * Gets the Villager or Wandering trader associated with this event
+     * @return the villager or wandering trader
+     */
+    @NotNull
+    public AbstractVillager getVillager() {
+        return villager;
+    }
+
+    /**
+     * Gets the associated trade with this event
+     * @return the trade
+     */
+    @NotNull
+    public MerchantRecipe getTrade() {
+        return trade;
+    }
+
+    /**
+     * Sets the trade. This is then used to determine the next prices
+     * @param trade the trade to use
+     */
+    public void setTrade(@Nullable MerchantRecipe trade) {
+        this.trade = trade;
+    }
+
+    /**
+     * @return will trade try to reward exp
+     */
+    public boolean isRewardingExp() {
+        return rewardExp;
+    }
+
+    /**
+     * Sets whether the trade will try to reward exp
+     * @param rewardExp try to reward exp
+     */
+    public void setRewardExp(boolean rewardExp) {
+        this.rewardExp = rewardExp;
+    }
+
+    /**
+     * @return whether or not the trade will count as a use of the trade
+     */
+    public boolean willIncreaseTradeUses() {
+        return increaseTradeUses;
+    }
+
+    /**
+     * Sets whether or not the trade will count as a use
+     * @param increaseTradeUses true to count/false to not count
+     */
+    public void setIncreaseTradeUses(boolean increaseTradeUses) {
+        this.increaseTradeUses = increaseTradeUses;
+    }
+
+    /**
+     * Gets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins
+     *
+     * @return true if this event is cancelled
+     */
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    /**
+     * Sets the cancellation state of this event. A cancelled event will not
+     * be executed in the server, but will still pass to other plugins.
+     *
+     * @param cancel true if you wish to cancel this event
+     */
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
Added:
> PlayerChangeBeaconEffectEvent
> PlayerFlowerPotManipulateEvent
> PlayerItemCooldownEvent
> PlayerLecternPageChangeEvent
> PlayerLoomPatternSelectEvent
> PlayerStonecutterRecipeSelectEvent
> PlayerTradeEvent

Remaining:
> Blocks events
> AsyncChatEvent
> PlayerNameEntityEvent (require some paper api)