### PR TITLE
Fix bug with player analytics (no such field)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -95,8 +95,11 @@
     private ChatVisibility field_71143_cn;
     private boolean field_71140_co = true;
     private long field_143005_bX = Util.func_211177_b();
-@@ -175,6 +_,21 @@
+@@ -173,8 +_,24 @@
+    public int field_71139_cq;
+    public boolean field_71137_h;
     public int field_71138_i;
++   public int ping = getPing();
     public boolean field_71136_j;
  
 +   // CraftBukkit start
@@ -1044,7 +1047,7 @@
           this.field_70170_p.func_217376_c(itementity);
           ItemStack itemstack = itementity.func_92059_d();
           if (p_146097_3_) {
-@@ -1405,8 +_,140 @@
+@@ -1405,8 +_,144 @@
        }
     }
  
@@ -1183,5 +1186,9 @@
 +
 +   public boolean initialized() {
 +      return this.initialized;
++   }
++
++   public int getPing() {
++      return field_71138_i;
     }
  }

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -1,12 +1,22 @@
 --- a/net/minecraft/entity/player/ServerPlayerEntity.java
 +++ b/net/minecraft/entity/player/ServerPlayerEntity.java
-@@ -11,10 +_,14 @@
+@@ -3,6 +_,8 @@
+ import com.google.common.collect.Lists;
+ import com.mojang.authlib.GameProfile;
+ import com.mojang.datafixers.util.Either;
++
++import java.lang.reflect.Field;
+ import java.util.Collection;
+ import java.util.Iterator;
+ import java.util.List;
+@@ -11,10 +_,15 @@
  import java.util.Random;
  import java.util.UUID;
  import javax.annotation.Nullable;
 +
 +import io.papermc.paper.event.packet.PlayerChunkLoadEvent;
 +import io.papermc.paper.event.packet.PlayerChunkUnloadEvent;
++import javafx.event.EventTarget;
  import net.minecraft.advancements.CriteriaTriggers;
  import net.minecraft.advancements.PlayerAdvancements;
  import net.minecraft.block.BlockState;
@@ -1047,7 +1057,7 @@
           this.field_70170_p.func_217376_c(itementity);
           ItemStack itemstack = itementity.func_92059_d();
           if (p_146097_3_) {
-@@ -1405,8 +_,144 @@
+@@ -1405,8 +_,149 @@
        }
     }
  
@@ -1190,5 +1200,10 @@
 +
 +   public int getPing() {
 +      return field_71138_i;
++   }
++
++   public void setLatency(int latency) {
++      this.field_71138_i = latency;
++      this.ping = latency;
     }
  }

--- a/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/ServerPlayNetHandler.java.patch
@@ -1924,14 +1924,18 @@
  
           signtileentity.func_70296_d();
           serverworld.func_184138_a(blockpos, blockstate, blockstate, 3);
-@@ -1381,6 +_,7 @@
+@@ -1381,9 +_,10 @@
     }
  
     public void func_147353_a(CKeepAlivePacket p_147353_1_) {
 +      PacketThreadUtil.func_218796_a(p_147353_1_, this, this.field_147369_b.func_71121_q()); // CraftBukkit
        if (this.field_194403_g && p_147353_1_.func_149460_c() == this.field_194404_h) {
           int i = (int)(Util.func_211177_b() - this.field_194402_f);
-          this.field_147369_b.field_71138_i = (this.field_147369_b.field_71138_i * 3 + i) / 4;
+-         this.field_147369_b.field_71138_i = (this.field_147369_b.field_71138_i * 3 + i) / 4;
++         this.field_147369_b.setLatency((this.field_147369_b.field_71138_i * 3 + i) / 4);
+          this.field_194403_g = false;
+       } else if (!this.func_217264_d()) {
+          this.func_194028_b(new TranslationTextComponent("disconnect.timeout"));
 @@ -1393,7 +_,17 @@
  
     public void func_147348_a(CPlayerAbilitiesPacket p_147348_1_) {


### PR DESCRIPTION
I fixed a bug with player analytics:
`Plan: Could not register Ping counter due to java.lang.NoSuchFieldException: no such field: net.minecraft.entity.player.ServerPlayerEntity.ping/int/getField`

This was due to the fact that with the mojang mappings the ping function changed name (It had become latency). So I added a "ping" field to the ServerPlayerEntity class which returns the value of latency.