### PR TITLE
Replace Skript 2.2dev37 through 2.5.3-1 (Fork of Original)

### DIFF
--- a/src/main/java/com/mohistmc/bukkit/AutoDeletePlugins.java
+++ b/src/main/java/com/mohistmc/bukkit/AutoDeletePlugins.java
@@ -15,7 +15,7 @@ public class AutoDeletePlugins {
     public static List<String> deletelist = new ArrayList<>();
 
     public static List<String> updatelist = new ArrayList<>(Arrays.asList(
-            "ch.njol.skript.Skript|2.2-dev37c#https://github.com/SkriptLang/Skript/releases/download/dev37c/Skript.jar", //Skript update
+            "ch.njol.skript.Skript|2.5.3#https://github.com/UeberallGebannt/Skript/releases/download/2.5.3-1/Skript.jar", //Skript update
             "com.massivecraft.factions.Factions|mohist#https://cdn.discordapp.com/attachments/436907032352653312/698176876656590918/Factions.jar")); //Factions update
 
     public static void jar() throws Exception {


### PR DESCRIPTION
This PR Replaces Skript 2.2dev37 in the AutoDeletePlugins class through 2.5.3-1 since that version works with Mohist