### PR TITLE
Fix dupe, more accurate previous fix

### DIFF
--- a/patches/minecraft/net/minecraft/stats/RecipeBookServer.java.patch
+++ b/patches/minecraft/net/minecraft/stats/RecipeBookServer.java.patch
@@ -1,24 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/stats/RecipeBookServer.java
 +++ ../src-work/minecraft/net/minecraft/stats/RecipeBookServer.java
-@@ -55,7 +55,9 @@
+@@ -55,7 +55,7 @@
  
      private void func_194081_a(SPacketRecipeBook.State p_194081_1_, EntityPlayerMP p_194081_2_, List<IRecipe> p_194081_3_)
      {
 -        p_194081_2_.field_71135_a.func_147359_a(new SPacketRecipeBook(p_194081_1_, p_194081_3_, Collections.emptyList(), this.field_192818_b, this.field_192819_c));
-+        if (p_194081_2_.field_71135_a != null) { // Fix unexpected NullPointerException
-+            net.minecraftforge.common.ForgeHooks.sendRecipeBook(p_194081_2_.field_71135_a, p_194081_1_, p_194081_3_, Collections.emptyList(), this.field_192818_b, this.field_192819_c);
-+        }
++        net.minecraftforge.common.ForgeHooks.sendRecipeBook(p_194081_2_.field_71135_a, p_194081_1_, p_194081_3_, Collections.emptyList(), this.field_192818_b, this.field_192819_c);
      }
  
      public NBTTagCompound func_192824_e()
-@@ -147,6 +149,8 @@
+@@ -147,6 +147,6 @@
  
      public void func_192826_c(EntityPlayerMP p_192826_1_)
      {
 -        p_192826_1_.field_71135_a.func_147359_a(new SPacketRecipeBook(SPacketRecipeBook.State.INIT, this.func_194079_d(), this.func_194080_e(), this.field_192818_b, this.field_192819_c));
-+        if (p_192826_1_.field_71135_a != null) { // Fix unexpected NullPointerException
-+            net.minecraftforge.common.ForgeHooks.sendRecipeBook(p_192826_1_.field_71135_a, SPacketRecipeBook.State.INIT, this.func_194079_d(), this.func_194080_e(), this.field_192818_b, this.field_192819_c);
-+        }
++        net.minecraftforge.common.ForgeHooks.sendRecipeBook(p_192826_1_.field_71135_a, SPacketRecipeBook.State.INIT, this.func_194079_d(), this.func_194080_e(), this.field_192818_b, this.field_192819_c);
 \ No newline at end of file
      }
  }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1159,6 +1159,11 @@ public class ForgeHooks {
     }
 
     public static void sendRecipeBook(NetHandlerPlayServer connection, State state, List<IRecipe> recipes, List<IRecipe> display, boolean isGuiOpen, boolean isFilteringCraftable) {
+        // Fix unexpected NullPointerException and log warn to console
+        if (connection == null) {
+            MohistMC.LOGGER.warn("Server tried send recipe book to client but connection was null. Is client already disconnected?");
+            return;
+        }
         NetworkDispatcher disp = NetworkDispatcher.get(connection.getNetworkManager());
         //Not sure how it could ever be null, but screw it lets protect against it. Could Error the client but we dont care if they are asking for this stuff in the wrong state!
         ConnectionType type = disp == null || disp.getConnectionType() == null ? ConnectionType.MODDED : disp.getConnectionType();

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -55,8 +55,14 @@ public class VanillaInventoryCodeHooks
         Pair<IItemHandler, Object> itemHandlerResult = getItemHandler(dest, EnumFacing.UP);
         if (itemHandlerResult == null)
             return null;
-		if (itemHandlerResult.getValue() instanceof IInventory)
-			return null;
+
+		    /* Not found in original forge repository (1.12.x/file commit 0683971).
+		    Adds dupes with tileentity with (not sure) crafting matrix inventories (e.g Tinkers's Construct Crafting Tool Table).
+		    If this lines is fixing some bugs - will try find more better solution.
+
+		    if (itemHandlerResult.getValue() instanceof IInventory)
+			      return null;
+			  */
 
         IItemHandler handler = itemHandlerResult.getKey();
 


### PR DESCRIPTION
Rewrote previous fix, now more accurate
Found if statement what not found in original forge repository that adds dupes with tileentity with (not sure) crafting matrix inventories (e.g Tinkers's Construct Crafting Tool Table).

How to reproduce dupe (for example in TConstuct)
1. Get any mohist build before this commit. I tested on 204.
2. Install latest TConstuct mod.
3. Get Crafting Station and place it.
4. Place hopper under crafting station.
5. Open crafting station and place any recipe (e.g diamond block)
6. Wait hopper works (don't close window)
7. When item was extracted - click on craft result slot.
8. Got diamonds? Now check hopper.
9. You're awesome!

And it is mohist issue, not forge or mod. On original forge hopper doesn't work with crafting station