### PR TITLE
Added paper light update patches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -521,7 +521,7 @@ project(':mohist') {
                     minecraft : MC_VERSION,
                     welcome   : "Welcome to the simple ${project.name.capitalize()} installer.",
                     data      : [
-                    ] as Map,
+] as Map,
                     processors: [
                     ]
             ]

--- a/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
@@ -8,15 +8,18 @@
  
  public class BlockCrops extends BlockBush implements IGrowable
  {
-@@ -70,6 +71,7 @@
+@@ -70,7 +71,9 @@
      {
          super.func_180650_b(p_180650_1_, p_180650_2_, p_180650_3_, p_180650_4_);
  
+-        if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9)
 +        if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent loading unloaded chunks when checking neighbor's light
-         if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9)
++        //if (worldIn.getLightFromNeighbors(pos.up()) >= 9)
++        if (p_180650_1_.isLightLevel(p_180650_2_, 9)) // Paper
          {
              int i = this.func_185527_x(p_180650_3_);
-@@ -78,9 +80,15 @@
+ 
+@@ -78,9 +81,15 @@
              {
                  float f = func_180672_a(this, p_180650_1_, p_180650_2_);
  
@@ -34,7 +37,7 @@
                  }
              }
          }
-@@ -96,7 +104,12 @@
+@@ -96,7 +105,12 @@
              i = j;
          }
  
@@ -48,7 +51,7 @@
      }
  
      protected int func_185529_b(World p_185529_1_)
-@@ -116,11 +129,11 @@
+@@ -116,11 +130,11 @@
                  float f1 = 0.0F;
                  IBlockState iblockstate = p_180672_1_.func_180495_p(blockpos.func_177982_a(i, 0, j));
  
@@ -62,7 +65,7 @@
                      {
                          f1 = 3.0F;
                      }
-@@ -161,7 +174,8 @@
+@@ -161,7 +175,8 @@
  
      public boolean func_180671_f(World p_180671_1_, BlockPos p_180671_2_, IBlockState p_180671_3_)
      {
@@ -72,7 +75,7 @@
      }
  
      protected Item func_149866_i()
-@@ -174,11 +188,32 @@
+@@ -174,11 +189,32 @@
          return Items.field_151015_O;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockGrass.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockGrass.java.patch
@@ -12,13 +12,15 @@
  
  public class BlockGrass extends Block implements IGrowable
  {
-@@ -38,9 +43,19 @@
+@@ -38,14 +43,32 @@
      {
          if (!p_180650_1_.field_72995_K)
          {
 -            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) < 4 && p_180650_1_.func_180495_p(p_180650_2_.func_177984_a()).func_185891_c() > 2)
 +            if (!p_180650_1_.func_175697_a(p_180650_2_, 3)) return; // Forge: prevent loading unloaded chunks when checking neighbor's light and spreading
-+            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) < 4 && p_180650_1_.func_180495_p(p_180650_2_.func_177984_a()).getLightOpacity(p_180650_1_, p_180650_2_.func_177984_a()) > 2)
++            //if (worldIn.getLightFromNeighbors(pos.up()) < 4 && worldIn.getBlockState(pos.up()).getLightOpacity(worldIn, pos.up()) > 2)
++            int lightLevel = -1;
++            if (p_180650_1_.func_180495_p(p_180650_2_.func_177984_a()).getLightOpacity(p_180650_1_, p_180650_2_.func_177984_a()) > 2 && (lightLevel = p_180650_1_.func_175671_l(p_180650_2_.func_177984_a())) < 4) // Paper - move light check to end to avoid unneeded light lookups
              {
 -                p_180650_1_.func_175656_a(p_180650_2_, Blocks.field_150346_d.func_176223_P());
 +                    org.bukkit.World bworld = p_180650_1_.getWorld();
@@ -34,12 +36,24 @@
              }
              else
              {
-@@ -58,9 +73,19 @@
+-                if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9)
++                //if (worldIn.getLightFromNeighbors(pos.up()) >= 9)
++                // Paper start
++                if (lightLevel == -1) {
++                    lightLevel = p_180650_1_.func_175671_l(p_180650_2_.func_177984_a());
++                }
++                if (lightLevel >= 9)
+                 {
++                    // Paper end
+                     for (int i = 0; i < 4; ++i)
+                     {
+                         BlockPos blockpos = p_180650_2_.func_177982_a(p_180650_4_.nextInt(3) - 1, p_180650_4_.nextInt(5) - 3, p_180650_4_.nextInt(3) - 1);
+@@ -58,9 +81,19 @@
                          IBlockState iblockstate = p_180650_1_.func_180495_p(blockpos.func_177984_a());
                          IBlockState iblockstate1 = p_180650_1_.func_180495_p(blockpos);
  
 -                        if (iblockstate1.func_177230_c() == Blocks.field_150346_d && iblockstate1.func_177229_b(BlockDirt.field_176386_a) == BlockDirt.DirtType.DIRT && p_180650_1_.func_175671_l(blockpos.func_177984_a()) >= 4 && iblockstate.func_185891_c() <= 2)
-+                        if (iblockstate1.func_177230_c() == Blocks.field_150346_d && iblockstate1.func_177229_b(BlockDirt.field_176386_a) == BlockDirt.DirtType.DIRT && p_180650_1_.func_175671_l(blockpos.func_177984_a()) >= 4 && iblockstate.getLightOpacity(p_180650_1_, p_180650_2_.func_177984_a()) <= 2)
++                        if (iblockstate1.func_177230_c() == Blocks.field_150346_d && iblockstate1.func_177229_b(BlockDirt.field_176386_a) == BlockDirt.DirtType.DIRT && iblockstate.getLightOpacity(p_180650_1_, p_180650_2_.func_177984_a()) <= 2 && p_180650_1_.func_175671_l(blockpos.func_177984_a()) >= 4) // Paper - move last check before isLightLevel to avoid unneeded light checks
                          {
 -                            p_180650_1_.func_175656_a(blockpos, Blocks.field_150349_c.func_176223_P());
 +//                            worldIn.setBlockState(blockpos, Blocks.GRASS.getDefaultState());
@@ -56,7 +70,7 @@
                          }
                      }
                  }
-@@ -96,18 +121,11 @@
+@@ -96,18 +129,11 @@
              {
                  if (j >= i / 16)
                  {
@@ -77,7 +91,7 @@
                          }
                          else
                          {
-@@ -115,7 +133,8 @@
+@@ -115,7 +141,8 @@
  
                              if (Blocks.field_150329_H.func_180671_f(p_176474_1_, blockpos1, iblockstate1))
                              {

--- a/patches/minecraft/net/minecraft/block/BlockSapling.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSapling.java.patch
@@ -25,13 +25,14 @@
  
      protected BlockSapling()
      {
-@@ -53,9 +59,32 @@
+@@ -53,9 +59,33 @@
          {
              super.func_180650_b(p_180650_1_, p_180650_2_, p_180650_3_, p_180650_4_);
  
 -            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9 && p_180650_4_.nextInt(7) == 0)
 +            if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent loading unloaded chunks when checking neighbor's light
-+            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9 && p_180650_4_.nextInt(Math.max(2, (int) (((100.0F / p_180650_1_.spigotConfig.saplingModifier) * 7) + 0.5F))) == 0)
++            /*if (worldIn.getLightFromNeighbors(pos.up()) >= 9*/ // Paper
++            if (p_180650_1_.isLightLevel(p_180650_2_.func_177984_a().func_177984_a(), 9) && p_180650_4_.nextInt(Math.max(2, (int) (((100.0F / p_180650_1_.spigotConfig.saplingModifier) * 7) + 0.5F))) == 0)
              {
 +                p_180650_1_.captureTreeGeneration = true;
                  this.func_176478_d(p_180650_1_, p_180650_2_, p_180650_3_, p_180650_4_);
@@ -59,7 +60,7 @@
              }
          }
      }
-@@ -74,7 +103,18 @@
+@@ -74,7 +104,18 @@
  
      public void func_176476_e(World p_176476_1_, BlockPos p_176476_2_, IBlockState p_176476_3_, Random p_176476_4_)
      {
@@ -79,7 +80,7 @@
          int i = 0;
          int j = 0;
          boolean flag = false;
-@@ -90,6 +130,7 @@
+@@ -90,6 +131,7 @@
                      {
                          if (this.func_181624_a(p_176476_1_, p_176476_2_, i, j, BlockPlanks.EnumType.SPRUCE))
                          {
@@ -87,7 +88,7 @@
                              worldgenerator = new WorldGenMegaPineTree(false, p_176476_4_.nextBoolean());
                              flag = true;
                              break label68;
-@@ -101,11 +142,13 @@
+@@ -101,11 +143,13 @@
                  {
                      i = 0;
                      j = 0;
@@ -101,7 +102,7 @@
                  worldgenerator = new WorldGenBirchTree(true, false);
                  break;
              case JUNGLE:
-@@ -119,6 +162,7 @@
+@@ -119,6 +163,7 @@
                      {
                          if (this.func_181624_a(p_176476_1_, p_176476_2_, i, j, BlockPlanks.EnumType.JUNGLE))
                          {
@@ -109,7 +110,7 @@
                              worldgenerator = new WorldGenMegaJungle(true, 10, 20, iblockstate, iblockstate1);
                              flag = true;
                              break label82;
-@@ -130,11 +174,13 @@
+@@ -130,11 +175,13 @@
                  {
                      i = 0;
                      j = 0;
@@ -123,7 +124,7 @@
                  worldgenerator = new WorldGenSavannaTree(true);
                  break;
              case DARK_OAK:
-@@ -146,6 +192,7 @@
+@@ -146,6 +193,7 @@
                      {
                          if (this.func_181624_a(p_176476_1_, p_176476_2_, i, j, BlockPlanks.EnumType.DARK_OAK))
                          {

--- a/patches/minecraft/net/minecraft/block/BlockStem.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStem.java.patch
@@ -16,13 +16,14 @@
  
  public class BlockStem extends BlockBush implements IGrowable
  {
-@@ -66,18 +66,19 @@
+@@ -66,18 +66,20 @@
      {
          super.func_180650_b(p_180650_1_, p_180650_2_, p_180650_3_, p_180650_4_);
  
 -        if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9)
 +        if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent loading unloaded chunks when checking neighbor's light
-+        if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9) 
++        //if (worldIn.getLightFromNeighbors(pos.up()) >= 9)
++        if (p_180650_1_.isLightLevel(p_180650_2_.func_177984_a(), 9)) // Paper
          {
              float f = BlockCrops.func_180672_a(this, p_180650_1_, p_180650_2_);
  
@@ -41,7 +42,7 @@
                  }
                  else
                  {
-@@ -90,13 +91,16 @@
+@@ -90,13 +92,16 @@
                      }
  
                      p_180650_2_ = p_180650_2_.func_177972_a(EnumFacing.Plane.HORIZONTAL.func_179518_a(p_180650_4_));
@@ -61,7 +62,7 @@
              }
          }
      }
-@@ -104,26 +108,30 @@
+@@ -104,26 +109,30 @@
      public void func_176482_g(World p_176482_1_, BlockPos p_176482_2_, IBlockState p_176482_3_)
      {
          int i = ((Integer)p_176482_3_.func_177229_b(field_176484_a)).intValue() + MathHelper.func_76136_a(p_176482_1_.field_73012_v, 2, 5);

--- a/patches/minecraft/net/minecraft/entity/monster/EntityMob.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityMob.java.patch
@@ -51,12 +51,31 @@
                          this.field_70170_p.func_72960_a(entityplayer, (byte)30);
                      }
                  }
-@@ -161,6 +168,7 @@
+@@ -153,17 +160,23 @@
+         }
+         else
+         {
+-            int i = this.field_70170_p.func_175671_l(blockpos);
++            //int i = this.world.getLightFromNeighbors(blockpos);
++            boolean passes; // Paper
+ 
+             if (this.field_70170_p.func_72911_I())
+             {
+                 int j = this.field_70170_p.func_175657_ab();
                  this.field_70170_p.func_175692_b(10);
-                 i = this.field_70170_p.func_175671_l(blockpos);
+-                i = this.field_70170_p.func_175671_l(blockpos);
++                //i = this.world.getLightFromNeighbors(blockpos);
++                passes = !field_70170_p.isLightLevel(blockpos, field_70146_Z.nextInt(9)); // Paper
                  this.field_70170_p.func_175692_b(j);
 +
-\ No newline at end of file
++            } else {
++                passes = !field_70170_p.isLightLevel(blockpos, field_70146_Z.nextInt(9)); // Paper
              }
  
-             return i <= this.field_70146_Z.nextInt(8);
+-            return i <= this.field_70146_Z.nextInt(8);
++            //return i <= this.rand.nextInt(8);
++            return passes; // Paper
+\ No newline at end of file
+         }
+     }
+ 

--- a/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
@@ -87,7 +87,7 @@
                      int k1 = k + MathHelper.func_76136_a(this.field_70146_Z, 7, 40) * MathHelper.func_76136_a(this.field_70146_Z, -1, 1);
  
 -                    if (this.field_70170_p.func_180495_p(new BlockPos(i1, j1 - 1, k1)).func_185896_q() && this.field_70170_p.func_175671_l(new BlockPos(i1, j1, k1)) < 10)
-+                    if (this.field_70170_p.func_180495_p(new BlockPos(i1, j1 - 1, k1)).isSideSolid(this.field_70170_p, new BlockPos(i1, j1 - 1, k1), net.minecraft.util.EnumFacing.UP) && this.field_70170_p.func_175671_l(new BlockPos(i1, j1, k1)) < 10)
++                    if (this.field_70170_p.func_180495_p(new BlockPos(i1, j1 - 1, k1)).isSideSolid(this.field_70170_p, new BlockPos(i1, j1 - 1, k1), net.minecraft.util.EnumFacing.UP) && this.field_70170_p.isLightLevel(new BlockPos(i1, j1, k1), 10)) // Paper
                      {
                          entityzombie.func_70107_b((double)i1, (double)j1, (double)k1);
  

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -1,10 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/server/MinecraftServer.java
 +++ ../src-work/minecraft/net/minecraft/server/MinecraftServer.java
-@@ -1,10 +1,13 @@
+@@ -1,10 +1,14 @@
  package net.minecraft.server;
  
 +import co.aikar.timings.MinecraftTimings;
 +import com.destroystokyo.paper.utils.CachedSizeConcurrentLinkedQueue;
++import com.destroystokyo.paper.world.PaperLightingQueue;
  import com.google.common.collect.Lists;
 -import com.google.common.collect.Queues;
 +import com.google.common.collect.Sets;
@@ -15,7 +16,7 @@
  import com.mojang.authlib.GameProfile;
  import com.mojang.authlib.GameProfileRepository;
  import com.mojang.authlib.minecraft.MinecraftSessionService;
-@@ -13,29 +16,34 @@
+@@ -13,29 +17,34 @@
  import io.netty.buffer.ByteBufOutputStream;
  import io.netty.buffer.Unpooled;
  import io.netty.handler.codec.base64.Base64;
@@ -52,7 +53,7 @@
  import net.minecraft.advancements.AdvancementManager;
  import net.minecraft.advancements.FunctionManager;
  import net.minecraft.command.CommandBase;
-@@ -55,6 +63,7 @@
+@@ -55,6 +64,7 @@
  import net.minecraft.profiler.Profiler;
  import net.minecraft.profiler.Snooper;
  import net.minecraft.server.dedicated.DedicatedServer;
@@ -60,9 +61,21 @@
  import net.minecraft.server.management.PlayerList;
  import net.minecraft.server.management.PlayerProfileCache;
  import net.minecraft.util.IProgressUpdate;
-@@ -79,33 +88,48 @@
- import net.minecraft.world.WorldSettings;
- import net.minecraft.world.WorldType;
+@@ -68,44 +78,50 @@
+ import net.minecraft.util.math.MathHelper;
+ import net.minecraft.util.text.ITextComponent;
+ import net.minecraft.util.text.TextComponentString;
+-import net.minecraft.world.EnumDifficulty;
+-import net.minecraft.world.GameType;
+-import net.minecraft.world.MinecraftException;
+-import net.minecraft.world.ServerWorldEventHandler;
+-import net.minecraft.world.World;
+-import net.minecraft.world.WorldServer;
+-import net.minecraft.world.WorldServerDemo;
+-import net.minecraft.world.WorldServerMulti;
+-import net.minecraft.world.WorldSettings;
+-import net.minecraft.world.WorldType;
++import net.minecraft.world.*;
  import net.minecraft.world.chunk.storage.AnvilSaveConverter;
 +import net.minecraft.world.chunk.storage.AnvilSaveHandler;
  import net.minecraft.world.storage.ISaveFormat;
@@ -115,7 +128,7 @@
      private PlayerList field_71318_t;
      private boolean field_71317_u = true;
      private boolean field_71316_v;
-@@ -123,11 +147,11 @@
+@@ -123,11 +139,11 @@
      private int field_71280_D;
      private int field_143008_E;
      public final long[] field_71311_j = new long[100];
@@ -129,7 +142,7 @@
      private String field_71287_L;
      private boolean field_71288_M;
      private boolean field_71289_N;
-@@ -143,12 +167,39 @@
+@@ -143,12 +159,39 @@
      private final GameProfileRepository field_152365_W;
      private final PlayerProfileCache field_152366_X;
      private long field_147142_T;
@@ -171,7 +184,7 @@
      public MinecraftServer(File p_i47054_1_, Proxy p_i47054_2_, DataFixer p_i47054_3_, YggdrasilAuthenticationService p_i47054_4_, MinecraftSessionService p_i47054_5_, GameProfileRepository p_i47054_6_, PlayerProfileCache p_i47054_7_)
      {
          this.field_110456_c = p_i47054_2_;
-@@ -161,8 +212,36 @@
+@@ -161,8 +204,36 @@
          this.field_71321_q = this.func_175582_h();
          this.field_71310_m = new AnvilSaveConverter(p_i47054_1_, p_i47054_3_);
          this.field_184112_s = p_i47054_3_;
@@ -208,7 +221,7 @@
      public ServerCommandManager func_175582_h()
      {
          return new ServerCommandManager(this);
-@@ -220,83 +299,94 @@
+@@ -220,83 +291,94 @@
  
      public void func_71247_a(String p_71247_1_, String p_71247_2_, long p_71247_3_, WorldType p_71247_5_, String p_71247_6_)
      {
@@ -357,7 +370,7 @@
      }
  
      public void func_71222_d()
-@@ -308,9 +398,12 @@
+@@ -308,9 +390,12 @@
          int i1 = 0;
          this.func_71192_d("menu.generatingTerrain");
          int j1 = 0;
@@ -372,7 +385,7 @@
          long k1 = func_130071_aq();
  
          for (int l1 = -192; l1 <= 192 && this.func_71278_l(); l1 += 16)
-@@ -321,7 +414,7 @@
+@@ -321,7 +406,7 @@
  
                  if (j2 - k1 > 1000L)
                  {
@@ -381,7 +394,7 @@
                      k1 = j2;
                  }
  
-@@ -379,13 +472,13 @@
+@@ -379,13 +464,13 @@
  
      public void func_71267_a(boolean p_71267_1_)
      {
@@ -397,7 +410,7 @@
                  }
  
                  try
-@@ -400,10 +493,24 @@
+@@ -400,10 +485,24 @@
          }
      }
  
@@ -425,7 +438,7 @@
          if (this.func_147137_ag() != null)
          {
              this.func_147137_ag().func_151268_b();
-@@ -411,14 +518,15 @@
+@@ -411,14 +510,15 @@
  
          if (this.field_71318_t != null)
          {
@@ -443,7 +456,7 @@
  
              for (WorldServer worldserver : this.field_71305_c)
              {
-@@ -428,21 +536,40 @@
+@@ -428,21 +528,40 @@
                  }
              }
  
@@ -486,7 +499,7 @@
      }
  
      public boolean func_71278_l()
-@@ -455,65 +582,72 @@
+@@ -455,65 +574,72 @@
          this.field_71317_u = false;
      }
  
@@ -589,7 +602,7 @@
              CrashReport crashreport = null;
  
              if (throwable1 instanceof ReportedException)
-@@ -522,35 +656,43 @@
+@@ -522,35 +648,43 @@
              }
              else
              {
@@ -638,7 +651,7 @@
                  this.func_71240_o();
              }
          }
-@@ -572,15 +714,17 @@
+@@ -572,15 +706,17 @@
              try
              {
                  BufferedImage bufferedimage = ImageIO.read(file1);
@@ -659,7 +672,7 @@
              }
              finally
              {
-@@ -615,9 +759,18 @@
+@@ -615,9 +751,18 @@
      {
      }
  
@@ -680,7 +693,7 @@
          ++this.field_71315_w;
  
          if (this.field_71295_T)
-@@ -634,7 +787,7 @@
+@@ -634,7 +779,7 @@
          {
              this.field_147142_T = i;
              this.field_147147_p.func_151319_a(new ServerStatusResponse.Players(this.func_71275_y(), this.func_71233_x()));
@@ -689,7 +702,7 @@
              int j = MathHelper.func_76136_a(this.field_147146_q, 0, this.func_71233_x() - agameprofile.length);
  
              for (int k = 0; k < agameprofile.length; ++k)
-@@ -644,9 +797,9 @@
+@@ -644,9 +789,9 @@
  
              Collections.shuffle(Arrays.asList(agameprofile));
              this.field_147147_p.func_151318_b().func_151330_a(agameprofile);
@@ -701,7 +714,7 @@
          {
              this.field_71304_b.func_76320_a("save");
              this.field_71318_t.func_72389_g();
-@@ -654,6 +807,7 @@
+@@ -654,6 +799,7 @@
              this.field_71304_b.func_76319_b();
          }
  
@@ -709,12 +722,13 @@
          this.field_71304_b.func_76320_a("tallying");
          this.field_71311_j[this.field_71315_w % 100] = System.nanoTime() - i;
          this.field_71304_b.func_76319_b();
-@@ -671,87 +825,124 @@
+@@ -671,87 +817,125 @@
  
          this.field_71304_b.func_76319_b();
          this.field_71304_b.func_76319_b();
 +        net.minecraftforge.fml.common.FMLCommonHandler.instance().onPostServerTick();
 +        org.spigotmc.WatchdogThread.tick(); // Spigot
++        PaperLightingQueue.processQueue(i); // Paper
 +        WatchMohist.update();
 +        co.aikar.timings.TimingsManager.FULL_SERVER_TICK.stopTiming(); // Paper
      }
@@ -883,7 +897,7 @@
  
          this.field_71304_b.func_76319_b();
      }
-@@ -763,8 +954,11 @@
+@@ -763,8 +947,11 @@
  
      public void func_71256_s()
      {
@@ -897,7 +911,7 @@
      }
  
      public File func_71209_f(String p_71209_1_)
-@@ -779,16 +973,25 @@
+@@ -779,16 +966,25 @@
  
      public WorldServer func_71218_a(int p_71218_1_)
      {
@@ -928,7 +942,7 @@
      public String func_71249_w()
      {
          return "1.12.2";
-@@ -816,7 +1019,7 @@
+@@ -816,7 +1012,7 @@
  
      public String getServerModName()
      {
@@ -937,7 +951,7 @@
      }
  
      public CrashReport func_71230_b(CrashReport p_71230_1_)
-@@ -845,7 +1048,7 @@
+@@ -845,7 +1041,7 @@
  
      public List<String> func_184104_a(ICommandSender p_184104_1_, String p_184104_2_, @Nullable BlockPos p_184104_3_, boolean p_184104_4_)
      {
@@ -946,7 +960,7 @@
          boolean flag = p_184104_2_.startsWith("/");
  
          if (flag)
-@@ -862,11 +1065,9 @@
+@@ -862,11 +1058,9 @@
              {
                  if (CommandBase.func_71523_a(s2, s1))
                  {
@@ -959,7 +973,7 @@
          }
          else
          {
-@@ -879,27 +1080,29 @@
+@@ -879,27 +1073,29 @@
                  {
                      if (flag1 && !p_184104_4_)
                      {
@@ -995,7 +1009,7 @@
      }
  
      public void func_145747_a(ITextComponent p_145747_1_)
-@@ -947,13 +1150,11 @@
+@@ -947,13 +1143,11 @@
          this.field_71294_K = p_71261_1_;
      }
  
@@ -1009,7 +1023,7 @@
      public String func_71221_J()
      {
          return this.field_71287_L;
-@@ -966,7 +1167,7 @@
+@@ -966,7 +1160,7 @@
  
      public void func_147139_a(EnumDifficulty p_147139_1_)
      {
@@ -1018,7 +1032,7 @@
          {
              if (worldserver1 != null)
              {
-@@ -1048,9 +1249,9 @@
+@@ -1048,9 +1242,9 @@
          p_70000_1_.func_152768_a("avg_tick_ms", Integer.valueOf((int)(MathHelper.func_76127_a(this.field_71311_j) * 1.0E-6D)));
          int l = 0;
  
@@ -1030,7 +1044,7 @@
              {
                  if (worldserver1 != null)
                  {
-@@ -1088,7 +1289,8 @@
+@@ -1088,7 +1282,8 @@
  
      public boolean func_71266_T()
      {
@@ -1040,7 +1054,7 @@
      }
  
      public void func_71229_d(boolean p_71229_1_)
-@@ -1182,7 +1384,7 @@
+@@ -1182,7 +1377,7 @@
  
      public void func_71235_a(GameType p_71235_1_)
      {
@@ -1049,7 +1063,7 @@
          {
              worldserver1.func_72912_H().func_76060_a(p_71235_1_);
          }
-@@ -1285,7 +1487,7 @@
+@@ -1285,7 +1480,7 @@
      @Nullable
      public Entity func_175576_a(UUID p_175576_1_)
      {
@@ -1058,7 +1072,7 @@
          {
              if (worldserver1 != null)
              {
-@@ -1311,6 +1513,11 @@
+@@ -1311,6 +1506,11 @@
          return this;
      }
  
@@ -1070,7 +1084,7 @@
      public int func_175580_aG()
      {
          return 29999984;
-@@ -1320,15 +1527,14 @@
+@@ -1320,15 +1520,14 @@
      {
          Validate.notNull(p_175586_1_);
  
@@ -1091,7 +1105,7 @@
          }
          else
          {
-@@ -1409,124 +1615,42 @@
+@@ -1409,124 +1608,42 @@
      }
  
      @SideOnly(Side.SERVER)
@@ -1233,7 +1247,7 @@
          }
      }
  
-@@ -1539,7 +1663,8 @@
+@@ -1539,7 +1656,8 @@
      @SideOnly(Side.SERVER)
      public boolean func_71239_B()
      {
@@ -1243,7 +1257,7 @@
      }
  
      @SideOnly(Side.SERVER)
-@@ -1598,4 +1723,14 @@
+@@ -1598,4 +1716,14 @@
      {
          return this.field_175590_aa;
      }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -325,7 +325,7 @@
          if (this.func_189509_E(p_180501_1_))
          {
              return false;
-@@ -308,24 +499,51 @@
+@@ -308,24 +499,52 @@
          else
          {
              Chunk chunk = this.func_175726_f(p_180501_1_);
@@ -355,7 +355,9 @@
 +                if (p_180501_2_.getLightOpacity(this, p_180501_1_) != oldOpacity || p_180501_2_.getLightValue(this, p_180501_1_) != oldLight)
                  {
                      this.field_72984_F.func_76320_a("checkLight");
-                     this.func_175664_x(p_180501_1_);
+-                    this.func_175664_x(p_180501_1_);
++                    BlockPos finalPos = p_180501_1_; // Final for next line
++                    chunk.runOrQueueLightUpdate(() -> this.func_175664_x(finalPos)); // Paper - Queue light update
                      this.field_72984_F.func_76319_b();
                  }
  
@@ -380,7 +382,7 @@
                      this.func_184138_a(p_180501_1_, iblockstate, p_180501_2_, p_180501_3_);
                  }
  
-@@ -342,8 +560,6 @@
+@@ -342,8 +561,6 @@
                  {
                      this.func_190522_c(p_180501_1_, block);
                  }
@@ -389,7 +391,7 @@
              }
          }
      }
-@@ -358,7 +574,7 @@
+@@ -358,7 +575,7 @@
          IBlockState iblockstate = this.func_180495_p(p_175655_1_);
          Block block = iblockstate.func_177230_c();
  
@@ -398,7 +400,7 @@
          {
              return false;
          }
-@@ -392,6 +608,11 @@
+@@ -392,6 +609,11 @@
      {
          if (this.field_72986_A.func_76067_t() != WorldType.field_180272_g)
          {
@@ -410,7 +412,7 @@
              this.func_175685_c(p_175722_1_, p_175722_2_, p_175722_3_);
          }
      }
-@@ -441,6 +662,8 @@
+@@ -441,6 +663,8 @@
  
      public void func_175685_c(BlockPos p_175685_1_, Block p_175685_2_, boolean p_175685_3_)
      {
@@ -419,7 +421,7 @@
          this.func_190524_a(p_175685_1_.func_177976_e(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177974_f(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177977_b(), p_175685_2_, p_175685_1_);
-@@ -456,6 +679,11 @@
+@@ -456,6 +680,11 @@
  
      public void func_175695_a(BlockPos p_175695_1_, Block p_175695_2_, EnumFacing p_175695_3_)
      {
@@ -431,7 +433,7 @@
          if (p_175695_3_ != EnumFacing.WEST)
          {
              this.func_190524_a(p_175695_1_.func_177976_e(), p_175695_2_, p_175695_1_);
-@@ -495,6 +723,15 @@
+@@ -495,6 +724,15 @@
  
              try
              {
@@ -447,7 +449,7 @@
                  iblockstate.func_189546_a(this, p_190524_1_, p_190524_2_, p_190524_3_);
              }
              catch (Throwable throwable)
-@@ -507,7 +744,7 @@
+@@ -507,7 +745,7 @@
                      {
                          try
                          {
@@ -456,7 +458,7 @@
                          }
                          catch (Throwable var2)
                          {
-@@ -527,12 +764,17 @@
+@@ -527,12 +765,17 @@
          {
              IBlockState iblockstate = this.func_180495_p(p_190529_1_);
  
@@ -476,7 +478,7 @@
                  catch (Throwable throwable)
                  {
                      CrashReport crashreport = CrashReport.func_85055_a(throwable, "Exception while updating neighbours");
-@@ -588,7 +830,7 @@
+@@ -588,7 +831,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos1);
  
@@ -485,7 +487,7 @@
                      {
                          return false;
                      }
-@@ -611,7 +853,6 @@
+@@ -611,11 +854,45 @@
              {
                  p_175699_1_ = new BlockPos(p_175699_1_.func_177958_n(), 255, p_175699_1_.func_177952_p());
              }
@@ -493,7 +495,55 @@
              return this.func_175726_f(p_175699_1_).func_177443_a(p_175699_1_, 0);
          }
      }
-@@ -740,7 +981,7 @@
+ 
++    // Paper start - test if meets light level, return faster
++    // logic copied from below
++    public boolean isLightLevel(BlockPos blockposition, int level) {
++        if (blockposition.isValidLocation()) {
++            if (this.func_180495_p(blockposition).func_185916_f()) {
++                if (this.func_175721_c(blockposition.func_177984_a(), false) >= level) {
++                    return true;
++                }
++                if (this.func_175721_c(blockposition.func_177974_f(), false) >= level) {
++                    return true;
++                }
++                if (this.func_175721_c(blockposition.func_177976_e(), false) >= level) {
++                    return true;
++                }
++                if (this.func_175721_c(blockposition.func_177968_d(), false) >= level) {
++                    return true;
++                }
++                if (this.func_175721_c(blockposition.func_177978_c(), false) >= level) {
++                    return true;
++                }
++                return false;
++            } else {
++                if (blockposition.func_177956_o() >= 256) {
++                    blockposition = new BlockPos(blockposition.func_177958_n(), 255, blockposition.func_177952_p());
++                }
++
++                Chunk chunk = this.func_175726_f(blockposition);
++                return chunk.func_177443_a(blockposition, this.func_175657_ab()) >= level;
++            }
++        } else {
++            return true;
++        }
++    }
++    // Paper end
++
+     public int func_175671_l(BlockPos p_175671_1_)
+     {
+         return this.func_175721_c(p_175671_1_, true);
+@@ -666,6 +943,8 @@
+                     p_175721_1_ = new BlockPos(p_175721_1_.func_177958_n(), 255, p_175721_1_.func_177952_p());
+                 }
+ 
++                if (!this.func_175667_e(p_175721_1_)) return 0; // Paper
++
+                 Chunk chunk = this.func_175726_f(p_175721_1_);
+                 return chunk.func_177443_a(p_175721_1_, this.field_73008_k);
+             }
+@@ -740,7 +1019,7 @@
              }
  
              if (!this.func_175701_a(p_175705_2_))
@@ -502,7 +552,7 @@
                  return p_175705_1_.field_77198_c;
              }
              else if (!this.func_175667_e(p_175705_2_))
-@@ -793,7 +1034,7 @@
+@@ -793,7 +1072,7 @@
          }
  
          if (!this.func_175701_a(p_175642_2_))
@@ -511,7 +561,7 @@
              return p_175642_1_.field_77198_c;
          }
          else if (!this.func_175667_e(p_175642_2_))
-@@ -810,7 +1051,7 @@
+@@ -810,7 +1089,7 @@
      public void func_175653_a(EnumSkyBlock p_175653_1_, BlockPos p_175653_2_, int p_175653_3_)
      {
          if (this.func_175701_a(p_175653_2_))
@@ -520,7 +570,7 @@
              if (this.func_175667_e(p_175653_2_))
              {
                  Chunk chunk = this.func_175726_f(p_175653_2_);
-@@ -849,6 +1090,17 @@
+@@ -849,6 +1128,17 @@
  
      public IBlockState func_180495_p(BlockPos p_180495_1_)
      {
@@ -538,7 +588,7 @@
          if (this.func_189509_E(p_180495_1_))
          {
              return Blocks.field_150350_a.func_176223_P();
-@@ -862,7 +1114,7 @@
+@@ -862,7 +1152,7 @@
  
      public boolean func_72935_r()
      {
@@ -547,7 +597,7 @@
      }
  
      @Nullable
-@@ -1065,6 +1317,13 @@
+@@ -1065,6 +1355,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -561,7 +611,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1112,12 +1371,68 @@
+@@ -1112,12 +1409,68 @@
  
      public boolean func_72942_c(Entity p_72942_1_)
      {
@@ -630,7 +680,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1140,31 +1455,135 @@
+@@ -1140,31 +1493,135 @@
                  this.func_72854_c();
              }
  
@@ -768,7 +818,7 @@
          if (p_72900_1_.func_184207_aI())
          {
              p_72900_1_.func_184226_ay();
-@@ -1187,11 +1606,12 @@
+@@ -1187,11 +1644,12 @@
  
      public void func_72973_f(Entity p_72973_1_)
      {
@@ -782,7 +832,7 @@
              this.field_73010_i.remove(p_72973_1_);
              this.func_72854_c();
          }
-@@ -1203,8 +1623,15 @@
+@@ -1203,8 +1661,15 @@
          {
              this.func_72964_e(i, j).func_76622_b(p_72973_1_);
          }
@@ -800,7 +850,7 @@
          this.func_72847_b(p_72973_1_);
      }
  
-@@ -1227,6 +1654,7 @@
+@@ -1227,6 +1692,7 @@
          IBlockState iblockstate = Blocks.field_150348_b.func_176223_P();
          BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
@@ -808,7 +858,7 @@
          try
          {
              for (int k1 = i; k1 < j; ++k1)
-@@ -1269,7 +1697,7 @@
+@@ -1269,7 +1735,7 @@
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
  
@@ -817,7 +867,7 @@
                                  {
                                      boolean flag5 = true;
                                      return flag5;
-@@ -1290,6 +1718,11 @@
+@@ -1290,6 +1756,11 @@
  
      public List<AxisAlignedBB> func_184144_a(@Nullable Entity p_184144_1_, AxisAlignedBB p_184144_2_)
      {
@@ -829,7 +879,7 @@
          List<AxisAlignedBB> list = Lists.<AxisAlignedBB>newArrayList();
          this.func_191504_a(p_184144_1_, p_184144_2_, false, list);
  
-@@ -1319,11 +1752,12 @@
+@@ -1319,11 +1790,12 @@
                  }
              }
          }
@@ -844,7 +894,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1361,19 +1795,38 @@
+@@ -1361,19 +1833,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -885,7 +935,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1386,6 +1839,12 @@
+@@ -1386,6 +1877,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -898,7 +948,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1393,9 +1852,7 @@
+@@ -1393,9 +1890,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -909,7 +959,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1444,20 +1901,25 @@
+@@ -1444,20 +1939,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -938,7 +988,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1467,6 +1929,12 @@
+@@ -1467,6 +1967,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -951,7 +1001,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1522,9 +1990,9 @@
+@@ -1522,9 +2028,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -963,7 +1013,7 @@
              {
                  break;
              }
-@@ -1536,6 +2004,12 @@
+@@ -1536,6 +2042,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -976,7 +1026,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1567,9 +2041,14 @@
+@@ -1567,9 +2079,14 @@
          for (int i = 0; i < this.field_73007_j.size(); ++i)
          {
              Entity entity = this.field_73007_j.get(i);
@@ -992,7 +1042,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1587,6 +2066,12 @@
+@@ -1587,6 +2104,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -1005,7 +1055,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1597,6 +2082,7 @@
+@@ -1597,6 +2120,7 @@
          }
  
          this.field_72984_F.func_76318_c("remove");
@@ -1013,7 +1063,7 @@
          this.field_72996_f.removeAll(this.field_72997_g);
  
          for (int k = 0; k < this.field_72997_g.size(); ++k)
-@@ -1618,11 +2104,19 @@
+@@ -1618,11 +2142,19 @@
  
          this.field_72997_g.clear();
          this.func_184147_l();
@@ -1036,7 +1086,7 @@
              Entity entity3 = entity2.func_184187_bx();
  
              if (entity3 != null)
-@@ -1641,13 +2135,27 @@
+@@ -1641,13 +2173,27 @@
              {
                  try
                  {
@@ -1065,7 +1115,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1665,34 +2173,50 @@
+@@ -1665,34 +2211,50 @@
                      this.func_72964_e(l1, i2).func_76622_b(entity2);
                  }
  
@@ -1127,7 +1177,7 @@
                  {
                      try
                      {
-@@ -1700,7 +2224,14 @@
+@@ -1700,7 +2262,14 @@
                          {
                              return String.valueOf((Object)TileEntity.func_190559_a(tileentity.getClass()));
                          });
@@ -1143,7 +1193,7 @@
                          this.field_72984_F.func_76319_b();
                      }
                      catch (Throwable throwable)
-@@ -1708,23 +2239,42 @@
+@@ -1708,23 +2277,42 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -1188,7 +1238,7 @@
          this.field_147481_N = false;
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
-@@ -1736,10 +2286,12 @@
+@@ -1736,10 +2324,12 @@
  
                  if (!tileentity1.func_145837_r())
                  {
@@ -1203,7 +1253,7 @@
  
                      if (this.func_175667_e(tileentity1.func_174877_v()))
                      {
-@@ -1747,6 +2299,12 @@
+@@ -1747,6 +2337,12 @@
                          IBlockState iblockstate = chunk.func_177435_g(tileentity1.func_174877_v());
                          chunk.func_177426_a(tileentity1.func_174877_v(), tileentity1);
                          this.func_184138_a(tileentity1.func_174877_v(), iblockstate, iblockstate, 3);
@@ -1216,7 +1266,7 @@
                      }
                  }
              }
-@@ -1754,6 +2312,8 @@
+@@ -1754,6 +2350,8 @@
              this.field_147484_a.clear();
          }
  
@@ -1225,7 +1275,7 @@
          this.field_72984_F.func_76319_b();
          this.field_72984_F.func_76319_b();
      }
-@@ -1764,12 +2324,18 @@
+@@ -1764,12 +2362,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -1245,7 +1295,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1785,6 +2351,11 @@
+@@ -1785,6 +2389,11 @@
      {
          if (this.field_147481_N)
          {
@@ -1257,7 +1307,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1803,17 +2374,32 @@
+@@ -1803,17 +2412,32 @@
  
      public void func_72866_a(Entity p_72866_1_, boolean p_72866_2_)
      {
@@ -1292,7 +1342,7 @@
  
          p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
          p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1831,7 +2417,9 @@
+@@ -1831,7 +2455,9 @@
              }
              else
              {
@@ -1302,7 +1352,7 @@
              }
          }
  
-@@ -1914,7 +2502,7 @@
+@@ -1914,7 +2540,7 @@
          {
              Entity entity4 = list.get(j2);
  
@@ -1311,7 +1361,7 @@
              {
                  return false;
              }
-@@ -1972,6 +2560,12 @@
+@@ -1972,6 +2598,12 @@
                  {
                      IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos.func_181079_c(l3, i4, j4));
  
@@ -1324,7 +1374,7 @@
                      if (iblockstate1.func_185904_a().func_76224_d())
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
-@@ -2011,6 +2605,11 @@
+@@ -2011,6 +2643,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -1336,7 +1386,7 @@
                      }
                  }
              }
-@@ -2050,6 +2649,16 @@
+@@ -2050,6 +2687,16 @@
                          IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate1.func_177230_c();
  
@@ -1353,7 +1403,7 @@
                          if (iblockstate1.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(i4 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate1.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2095,7 +2704,14 @@
+@@ -2095,7 +2742,14 @@
              {
                  for (int j4 = j3; j4 < k3; ++j4)
                  {
@@ -1369,7 +1419,7 @@
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
                          return true;
-@@ -2116,6 +2732,7 @@
+@@ -2116,6 +2770,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -1377,7 +1427,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2190,29 +2807,35 @@
+@@ -2190,29 +2845,35 @@
          return this.field_73020_y.func_73148_d();
      }
  
@@ -1419,7 +1469,7 @@
                  tileentity2 = this.func_189508_F(p_175625_1_);
              }
  
-@@ -2227,7 +2850,7 @@
+@@ -2227,7 +2888,7 @@
          {
              TileEntity tileentity2 = this.field_147484_a.get(j2);
  
@@ -1428,7 +1478,7 @@
              {
                  return tileentity2;
              }
-@@ -2238,14 +2861,19 @@
+@@ -2238,14 +2899,19 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -1449,7 +1499,7 @@
  
                      while (iterator1.hasNext())
                      {
-@@ -2253,16 +2881,19 @@
+@@ -2253,16 +2919,19 @@
  
                          if (tileentity2.func_174877_v().equals(p_175690_1_))
                          {
@@ -1471,7 +1521,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2277,11 +2908,14 @@
+@@ -2277,11 +2946,14 @@
          {
              tileentity2.func_145843_s();
              this.field_147484_a.remove(tileentity2);
@@ -1486,7 +1536,7 @@
                  this.field_147484_a.remove(tileentity2);
                  this.field_147482_g.remove(tileentity2);
                  this.field_175730_i.remove(tileentity2);
-@@ -2289,6 +2923,7 @@
+@@ -2289,6 +2961,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -1494,7 +1544,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2305,7 +2940,7 @@
+@@ -2305,7 +2978,7 @@
      public boolean func_175677_d(BlockPos p_175677_1_, boolean p_175677_2_)
      {
          if (this.func_189509_E(p_175677_1_))
@@ -1503,7 +1553,7 @@
              return false;
          }
          else
-@@ -2315,7 +2950,7 @@
+@@ -2315,7 +2988,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -1512,7 +1562,7 @@
              }
              else
              {
-@@ -2338,6 +2973,7 @@
+@@ -2338,6 +3011,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -1520,7 +1570,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2983,11 @@
+@@ -2347,6 +3021,11 @@
  
      protected void func_72947_a()
      {
@@ -1532,7 +1582,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +3001,11 @@
+@@ -2360,6 +3039,11 @@
  
      protected void func_72979_l()
      {
@@ -1544,7 +1594,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2451,6 +3097,11 @@
+@@ -2451,6 +3135,11 @@
                  }
  
                  this.field_73004_o = MathHelper.func_76131_a(this.field_73004_o, 0.0F, 1.0F);
@@ -1556,7 +1606,7 @@
              }
          }
      }
-@@ -2484,6 +3135,11 @@
+@@ -2484,6 +3173,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -1568,7 +1618,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +3181,11 @@
+@@ -2525,6 +3219,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -1580,7 +1630,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +3203,7 @@
+@@ -2542,7 +3241,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -1589,7 +1639,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +3235,10 @@
+@@ -2574,10 +3273,10 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -1603,7 +1653,7 @@
              {
                  k2 = 1;
              }
-@@ -2589,7 +3250,7 @@
+@@ -2589,7 +3288,7 @@
  
              if (k2 >= 15)
              {
@@ -1612,7 +1662,7 @@
              }
              else if (j2 >= 14)
              {
-@@ -2630,12 +3291,16 @@
+@@ -2630,12 +3329,16 @@
  
      public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
      {
@@ -1630,7 +1680,7 @@
              int j2 = 0;
              int k2 = 0;
              this.field_72984_F.func_76320_a("getBrightness");
-@@ -2673,7 +3338,7 @@
+@@ -2673,7 +3376,7 @@
                              int l5 = MathHelper.func_76130_a(k4 - k3);
                              int i6 = MathHelper.func_76130_a(l4 - l3);
  
@@ -1639,7 +1689,7 @@
                              {
                                  BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
-@@ -2683,7 +3348,8 @@
+@@ -2683,7 +3386,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -1649,7 +1699,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2725,7 +3391,7 @@
+@@ -2725,7 +3429,7 @@
                          int j9 = Math.abs(i8 - l3);
                          boolean flag = k2 < this.field_72994_J.length - 6;
  
@@ -1658,7 +1708,7 @@
                          {
                              if (this.func_175642_b(p_180500_1_, blockpos2.func_177976_e()) < k8)
                              {
-@@ -2790,11 +3456,31 @@
+@@ -2790,11 +3494,31 @@
  
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
@@ -1694,7 +1744,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2806,19 +3492,20 @@
+@@ -2806,19 +3530,20 @@
                  }
              }
          }
@@ -1722,7 +1772,7 @@
              }
          }
  
-@@ -2847,10 +3534,31 @@
+@@ -2847,10 +3572,31 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -1758,7 +1808,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2863,7 +3571,8 @@
+@@ -2863,7 +3609,8 @@
                  }
              }
          }
@@ -1768,7 +1818,7 @@
          return list;
      }
  
-@@ -2919,7 +3628,16 @@
+@@ -2919,7 +3666,16 @@
  
          for (Entity entity4 : this.field_72996_f)
          {
@@ -1786,7 +1836,7 @@
              {
                  ++j2;
              }
-@@ -2930,11 +3648,19 @@
+@@ -2930,11 +3686,19 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -1809,7 +1859,7 @@
          }
      }
  
-@@ -2948,18 +3674,24 @@
+@@ -2948,18 +3712,24 @@
          IBlockState iblockstate1 = this.func_180495_p(p_190527_2_);
          AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
  
@@ -1838,7 +1888,7 @@
      }
  
      public int func_181545_F()
-@@ -3042,7 +3774,7 @@
+@@ -3042,7 +3812,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -1847,7 +1897,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3124,6 +3856,11 @@
+@@ -3124,6 +3894,11 @@
          {
              EntityPlayer entityplayer1 = this.field_73010_i.get(j2);
  
@@ -1859,7 +1909,7 @@
              if (p_190525_9_.apply(entityplayer1))
              {
                  double d1 = entityplayer1.func_70092_e(p_190525_1_, p_190525_3_, p_190525_5_);
-@@ -3141,7 +3878,7 @@
+@@ -3141,7 +3916,7 @@
  
      public boolean func_175636_b(double p_175636_1_, double p_175636_3_, double p_175636_5_, double p_175636_7_)
      {
@@ -1868,7 +1918,7 @@
          {
              EntityPlayer entityplayer = this.field_73010_i.get(j2);
  
-@@ -3156,8 +3893,8 @@
+@@ -3156,8 +3931,8 @@
              }
          }
  
@@ -1879,7 +1929,7 @@
  
      @Nullable
      public EntityPlayer func_184142_a(Entity p_184142_1_, double p_184142_2_, double p_184142_4_)
-@@ -3180,7 +3917,6 @@
+@@ -3180,7 +3955,6 @@
          for (int j2 = 0; j2 < this.field_73010_i.size(); ++j2)
          {
              EntityPlayer entityplayer1 = this.field_73010_i.get(j2);
@@ -1887,7 +1937,7 @@
              if (!entityplayer1.field_71075_bZ.field_75102_a && entityplayer1.func_70089_S() && !entityplayer1.func_175149_v() && (p_184150_12_ == null || p_184150_12_.apply(entityplayer1)))
              {
                  double d1 = entityplayer1.func_70092_e(p_184150_1_, entityplayer1.field_70163_u, p_184150_5_);
-@@ -3208,6 +3944,8 @@
+@@ -3208,6 +3982,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -1896,7 +1946,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +4007,7 @@
+@@ -3269,7 +4045,7 @@
  
      public long func_72905_C()
      {
@@ -1905,7 +1955,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +4017,17 @@
+@@ -3279,17 +4055,17 @@
  
      public long func_72820_D()
      {
@@ -1926,7 +1976,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +4039,7 @@
+@@ -3301,7 +4077,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -1935,7 +1985,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +4059,18 @@
+@@ -3321,12 +4097,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -1954,7 +2004,7 @@
          return true;
      }
  
-@@ -3363,6 +4107,16 @@
+@@ -3363,6 +4145,16 @@
      {
      }
  
@@ -1971,7 +2021,7 @@
      public float func_72819_i(float p_72819_1_)
      {
          return (this.field_73018_p + (this.field_73017_q - this.field_73018_p) * p_72819_1_) * this.func_72867_j(p_72819_1_);
-@@ -3428,8 +4182,7 @@
+@@ -3428,8 +4220,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -1981,7 +2031,7 @@
      }
  
      @Nullable
-@@ -3490,12 +4243,12 @@
+@@ -3490,12 +4281,12 @@
  
      public int func_72800_K()
      {
@@ -1996,7 +2046,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +4292,7 @@
+@@ -3539,7 +4330,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -2005,7 +2055,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +4326,7 @@
+@@ -3573,7 +4364,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -2014,7 +2064,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +4334,15 @@
+@@ -3581,18 +4372,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -2037,7 +2087,7 @@
                      }
                  }
              }
-@@ -3655,9 +4405,131 @@
+@@ -3655,9 +4443,131 @@
          int j2 = p_72916_1_ * 16 + 8 - blockpos1.func_177958_n();
          int k2 = p_72916_2_ * 16 + 8 - blockpos1.func_177952_p();
          int l2 = 128;
@@ -2170,7 +2220,7 @@
      public void func_184135_a(Packet<?> p_184135_1_)
      {
          throw new UnsupportedOperationException("Can't send packets to server unless you're on the client.");
-@@ -3673,4 +4545,11 @@
+@@ -3673,4 +4583,11 @@
      {
          return null;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -1,11 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/world/chunk/Chunk.java
 +++ ../src-work/minecraft/net/minecraft/world/chunk/Chunk.java
-@@ -8,15 +8,19 @@
- import java.util.Map;
- import java.util.Random;
- import java.util.concurrent.ConcurrentLinkedQueue;
-+import java.util.stream.Collectors;
- import javax.annotation.Nullable;
+@@ -1,22 +1,20 @@
+ package net.minecraft.world.chunk;
+ 
++import com.destroystokyo.paper.PaperMCConfig;
+ import com.google.common.base.Predicate;
+ import com.google.common.collect.Maps;
+ import com.google.common.collect.Queues;
+-import java.util.Arrays;
+-import java.util.List;
+-import java.util.Map;
+-import java.util.Random;
+-import java.util.concurrent.ConcurrentLinkedQueue;
+-import javax.annotation.Nullable;
  import net.minecraft.block.Block;
 -import net.minecraft.block.ITileEntityProvider;
 +import net.minecraft.block.BlockSand;
@@ -21,18 +28,34 @@
  import net.minecraft.init.Biomes;
  import net.minecraft.init.Blocks;
  import net.minecraft.network.PacketBuffer;
-@@ -40,8 +44,9 @@
+@@ -29,6 +27,7 @@
+ import net.minecraft.util.math.ChunkPos;
+ import net.minecraft.util.math.MathHelper;
+ import net.minecraft.world.EnumSkyBlock;
++import com.destroystokyo.paper.world.PaperLightingQueue;
+ import net.minecraft.world.World;
+ import net.minecraft.world.WorldType;
+ import net.minecraft.world.biome.Biome;
+@@ -40,8 +39,17 @@
  import net.minecraftforge.fml.relauncher.SideOnly;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
 +import org.bukkit.Server;
  
 -public class Chunk
++import javax.annotation.Nullable;
++import java.util.Arrays;
++import java.util.List;
++import java.util.Map;
++import java.util.Random;
++import java.util.concurrent.ConcurrentLinkedQueue;
++import java.util.stream.Collectors;
++
 +public class Chunk implements net.minecraftforge.common.capabilities.ICapabilityProvider
  {
      private static final Logger field_150817_t = LogManager.getLogger();
      public static final ExtendedBlockStorage field_186036_a = null;
-@@ -50,13 +55,13 @@
+@@ -50,13 +58,13 @@
      private final int[] field_76638_b;
      private final boolean[] field_76639_c;
      private boolean field_76636_d;
@@ -50,11 +73,12 @@
      private boolean field_76646_k;
      private boolean field_150814_l;
      private boolean field_150815_m;
-@@ -68,7 +73,37 @@
+@@ -68,7 +76,38 @@
      private int field_76649_t;
      private final ConcurrentLinkedQueue<BlockPos> field_177447_w;
      public boolean field_189550_d;
 +    public gnu.trove.map.hash.TObjectIntHashMap<Class> entityCount = new gnu.trove.map.hash.TObjectIntHashMap<Class>(); // Spigot
++    public final PaperLightingQueue.LightingQueue lightingQueue = new PaperLightingQueue.LightingQueue(this);
  
 +    // CraftBukkit start - Neighbor loaded cache for chunk lighting and entity ticking
 +    private int neighbors = 0x1 << 12;
@@ -88,7 +112,7 @@
      public Chunk(World p_i1995_1_, int p_i1995_2_, int p_i1995_3_)
      {
          this.field_76652_q = new ExtendedBlockStorage[16];
-@@ -91,8 +126,14 @@
+@@ -91,8 +130,14 @@
  
          Arrays.fill(this.field_76638_b, -999);
          Arrays.fill(this.field_76651_r, (byte) - 1);
@@ -103,7 +127,7 @@
      public Chunk(World p_i45645_1_, ChunkPrimer p_i45645_2_, int p_i45645_3_, int p_i45645_4_)
      {
          this(p_i45645_1_, p_i45645_3_, p_i45645_4_);
-@@ -179,7 +220,7 @@
+@@ -179,7 +224,7 @@
                  {
                      IBlockState iblockstate = this.func_186032_a(j, l - 1, k);
  
@@ -112,7 +136,85 @@
                      {
                          this.field_76634_f[k << 4 | j] = l;
  
-@@ -452,12 +493,13 @@
+@@ -270,38 +315,40 @@
+         this.field_76650_s = true;
+     }
+ 
+-    private void func_150803_c(boolean p_150803_1_)
+-    {
++    // Paper start
++    public void runOrQueueLightUpdate(Runnable runnable) {
++        if (PaperMCConfig.queueLightUpdates) {
++            lightingQueue.add(runnable);
++        } else {
++            runnable.run();
++        }
++    }
++
++    private void func_150803_c(boolean p_150803_1_) {
+         this.field_76637_e.field_72984_F.func_76320_a("recheckGaps");
+ 
+-        if (this.field_76637_e.func_175697_a(new BlockPos(this.field_76635_g * 16 + 8, 0, this.field_76647_h * 16 + 8), 16))
+-        {
+-            for (int i = 0; i < 16; ++i)
+-            {
+-                for (int j = 0; j < 16; ++j)
+-                {
+-                    if (this.field_76639_c[i + j * 16])
+-                    {
++        //if (this.world.isAreaLoaded(new BlockPos(this.x * 16 + 8, 0, this.z * 16 + 8), 16)) {
++        if (this.areNeighborsLoaded(1)) { // Paper
++            for (int i = 0; i < 16; ++i) {
++                for (int j = 0; j < 16; ++j) {
++                    if (this.field_76639_c[i + j * 16]) {
+                         this.field_76639_c[i + j * 16] = false;
+                         int k = this.func_76611_b(i, j);
+                         int l = this.field_76635_g * 16 + i;
+                         int i1 = this.field_76647_h * 16 + j;
+                         int j1 = Integer.MAX_VALUE;
+ 
+-                        for (EnumFacing enumfacing : EnumFacing.Plane.HORIZONTAL)
+-                        {
++                        for (EnumFacing enumfacing : EnumFacing.Plane.HORIZONTAL) {
+                             j1 = Math.min(j1, this.field_76637_e.func_82734_g(l + enumfacing.func_82601_c(), i1 + enumfacing.func_82599_e()));
+                         }
+ 
+                         this.func_76599_g(l, i1, j1);
+ 
+-                        for (EnumFacing enumfacing1 : EnumFacing.Plane.HORIZONTAL)
+-                        {
++                        for (EnumFacing enumfacing1 : EnumFacing.Plane.HORIZONTAL) {
+                             this.func_76599_g(l + enumfacing1.func_82601_c(), i1 + enumfacing1.func_82599_e(), k);
+                         }
+ 
+-                        if (p_150803_1_)
+-                        {
++                        if (p_150803_1_) {
+                             this.field_76637_e.field_72984_F.func_76319_b();
+                             return;
+                         }
+@@ -310,9 +357,8 @@
+             }
+ 
+             this.field_76650_s = false;
++            this.field_76637_e.field_72984_F.func_76319_b();
+         }
+-
+-        this.field_76637_e.field_72984_F.func_76319_b();
+     }
+ 
+     private void func_76599_g(int p_76599_1_, int p_76599_2_, int p_76599_3_)
+@@ -331,7 +377,8 @@
+ 
+     private void func_76609_d(int p_76609_1_, int p_76609_2_, int p_76609_3_, int p_76609_4_)
+     {
+-        if (p_76609_4_ > p_76609_3_ && this.field_76637_e.func_175697_a(new BlockPos(p_76609_1_, 0, p_76609_2_), 16))
++        //if (endY > startY && this.world.isAreaLoaded(new BlockPos(x, 0, z), 16))
++        if (p_76609_4_ > p_76609_3_ && this.areNeighborsLoaded(1)) // Paper
+         {
+             for (int i = p_76609_3_; i < p_76609_4_; ++i)
+             {
+@@ -452,12 +499,13 @@
  
      public int func_177437_b(BlockPos p_177437_1_)
      {
@@ -128,7 +230,7 @@
      }
  
      public IBlockState func_177435_g(BlockPos p_177435_1_)
-@@ -539,6 +581,7 @@
+@@ -539,6 +587,7 @@
          {
              Block block = p_177436_2_.func_177230_c();
              Block block1 = iblockstate.func_177230_c();
@@ -136,7 +238,7 @@
              ExtendedBlockStorage extendedblockstorage = this.field_76652_q[j >> 4];
              boolean flag = false;
  
-@@ -556,14 +599,19 @@
+@@ -556,14 +605,19 @@
  
              extendedblockstorage.func_177484_a(i, j & 15, k, p_177436_2_);
  
@@ -158,18 +260,47 @@
                      this.field_76637_e.func_175713_t(p_177436_1_);
                  }
              }
-@@ -580,8 +628,7 @@
-                 }
-                 else
+@@ -577,52 +631,39 @@
+                 if (flag)
                  {
+                     this.func_76603_b();
+-                }
+-                else
+-                {
 -                    int j1 = p_177436_2_.func_185891_c();
 -                    int k1 = iblockstate.func_185891_c();
-+                    int j1 = p_177436_2_.getLightOpacity(this.field_76637_e, p_177436_1_);
++                } else {
++                    // Paper start
++                    this.runOrQueueLightUpdate(() -> { // Paper - Queue light update
  
-                     if (j1 > 0)
-                     {
-@@ -601,28 +648,19 @@
-                     }
+-                    if (j1 > 0)
+-                    {
+-                        if (j >= i1)
+-                        {
+-                            this.func_76615_h(i, j + 1, k);
++                        int j1 = p_177436_2_.getLightOpacity(this.field_76637_e, p_177436_1_);
++
++                        if (j1 > 0) {
++                            if (j >= i1) {
++                                this.func_76615_h(i, j + 1, k);
++                            }
++                        } else if (j == i1 - 1) {
++                            this.func_76615_h(i, j, k);
+                         }
+-                    }
+-                    else if (j == i1 - 1)
+-                    {
+-                        this.func_76615_h(i, j, k);
+-                    }
+ 
+-                    if (j1 != k1 && (j1 < k1 || this.func_177413_a(EnumSkyBlock.SKY, p_177436_1_) > 0 || this.func_177413_a(EnumSkyBlock.BLOCK, p_177436_1_) > 0))
+-                    {
+-                        this.func_76595_e(i, k);
+-                    }
++                        if (j1 != k1 && (j1 < k1 || this.func_177413_a(EnumSkyBlock.SKY, p_177436_1_) > 0 || this.func_177413_a(EnumSkyBlock.BLOCK, p_177436_1_) > 0)) {
++                            this.func_76595_e(i, k);
++                        }
++                    });
                  }
  
 -                if (block1 instanceof ITileEntityProvider)
@@ -201,7 +332,7 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -738,11 +776,29 @@
+@@ -738,11 +779,29 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -231,7 +362,7 @@
      }
  
      public void func_76622_b(Entity p_76622_1_)
-@@ -763,6 +819,23 @@
+@@ -763,6 +822,23 @@
          }
  
          this.field_76645_j[p_76608_2_].remove(p_76608_1_);
@@ -255,7 +386,7 @@
      }
  
      public boolean func_177444_d(BlockPos p_177444_1_)
-@@ -778,14 +851,23 @@
+@@ -778,14 +854,23 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -281,7 +412,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -795,14 +877,9 @@
+@@ -795,14 +880,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -297,7 +428,7 @@
  
          return tileentity;
      }
-@@ -819,10 +896,11 @@
+@@ -819,10 +899,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -310,7 +441,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,12 +932,14 @@
+@@ -854,12 +935,14 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -326,7 +457,7 @@
          this.field_76636_d = false;
  
          for (TileEntity tileentity : this.field_150816_i.values())
-@@ -869,8 +949,16 @@
+@@ -869,8 +952,16 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -344,7 +475,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +968,8 @@
+@@ -880,8 +971,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -355,7 +486,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +1006,8 @@
+@@ -918,8 +1009,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -366,7 +497,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -995,8 +1083,72 @@
+@@ -995,8 +1086,72 @@
          }
      }
  
@@ -439,7 +570,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1160,29 @@
+@@ -1008,8 +1163,29 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -469,7 +600,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1237,7 @@
+@@ -1064,7 +1240,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -478,7 +609,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1075,7 +1248,7 @@
+@@ -1075,7 +1251,7 @@
  
      public boolean func_150802_k()
      {
@@ -487,7 +618,7 @@
      }
  
      public boolean func_186035_j()
-@@ -1128,6 +1301,13 @@
+@@ -1128,6 +1304,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -501,7 +632,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1356,16 @@
+@@ -1176,10 +1359,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -518,7 +649,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1190,7 +1376,12 @@
+@@ -1190,7 +1379,12 @@
  
          if (k == 255)
          {
@@ -532,7 +663,7 @@
              k = Biome.func_185362_a(biome);
              this.field_76651_r[j << 4 | i] = (byte)(k & 255);
          }
-@@ -1244,13 +1435,13 @@
+@@ -1244,13 +1438,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -548,7 +679,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1265,6 +1456,7 @@
+@@ -1265,6 +1459,7 @@
  
      public void func_150809_p()
      {
@@ -556,7 +687,7 @@
          this.field_76646_k = true;
          this.field_150814_l = true;
          BlockPos blockpos = new BlockPos(this.field_76635_g << 4, 0, this.field_76647_h << 4);
-@@ -1303,6 +1495,7 @@
+@@ -1303,6 +1498,7 @@
                  this.field_150814_l = false;
              }
          }
@@ -564,7 +695,7 @@
      }
  
      private void func_177441_y()
-@@ -1381,7 +1574,7 @@
+@@ -1381,7 +1577,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -573,7 +704,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1613,7 @@
+@@ -1420,6 +1616,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -581,7 +712,7 @@
          }
      }
  
-@@ -1433,6 +1627,10 @@
+@@ -1433,6 +1630,10 @@
          return this.field_76645_j;
      }
  
@@ -592,7 +723,7 @@
      public boolean func_177419_t()
      {
          return this.field_76646_k;
-@@ -1489,4 +1687,55 @@
+@@ -1489,4 +1690,55 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -159,7 +159,7 @@
                  Iterator<Long> iterator = this.field_73248_b.iterator();
  
                  for (int i = 0; i < 100 && iterator.hasNext(); iterator.remove())
-@@ -233,21 +293,56 @@
+@@ -233,21 +293,57 @@
  
                      if (chunk != null && chunk.field_189550_d)
                      {
@@ -192,6 +192,7 @@
 +            return false;
 +        }
 +        save = event.isSaveChunk();
++        chunk.lightingQueue.processUnload(); // Paper
 +
 +        // Update neighbor counts
 +        for (int x = -2; x < 3; x++) {

--- a/src/main/java/com/destroystokyo/paper/MCUtil.java
+++ b/src/main/java/com/destroystokyo/paper/MCUtil.java
@@ -13,8 +13,11 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityHopper;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.ChunkProviderServer;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
@@ -204,5 +207,29 @@ public final class MCUtil {
 
     public static World getNMSWorld(@Nonnull org.bukkit.entity.Entity entity) {
         return getNMSWorld(entity.getWorld());
+    }
+
+    /**
+     * Gets a chunk without changing its boolean for should unload
+     * @param world
+     * @param x chunkX
+     * @param z chunkZ
+     * @return
+     */
+    @Nullable
+    public static Chunk getLoadedChunkWithoutMarkingActive(World world, int x, int z) {
+        return ((ChunkProviderServer) world.chunkProvider).id2ChunkMap.get(ChunkPos.asLong(x, z));
+    }
+
+    /**
+     * Gets a chunk without changing its boolean for should unload
+     * @param provider
+     * @param x chunkX
+     * @param z chunkZ
+     * @return
+     */
+    @Nullable
+    public static Chunk getLoadedChunkWithoutMarkingActive(IChunkProvider provider, int x, int z) {
+        return ((ChunkProviderServer) provider).id2ChunkMap.get(ChunkPos.asLong(x, z));
     }
 }

--- a/src/main/java/com/destroystokyo/paper/PaperMCConfig.java
+++ b/src/main/java/com/destroystokyo/paper/PaperMCConfig.java
@@ -5,6 +5,11 @@ import co.aikar.timings.TimingsManager;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -16,10 +21,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
-import org.bukkit.Bukkit;
-import org.bukkit.command.Command;
-import org.bukkit.configuration.InvalidConfigurationException;
-import org.bukkit.configuration.file.YamlConfiguration;
 
 public class PaperMCConfig {
 
@@ -309,5 +310,11 @@ public class PaperMCConfig {
             maxBookPageSize = 2560;
             maxBookTotalSizeMultiplier = 0.98D;
         }
+    }
+
+    public static boolean queueLightUpdates;
+    private static void queueLightUpdates() {
+        queueLightUpdates = getBoolean("queue-light-updates", false);
+        log("Lighting Queue enabled: " + queueLightUpdates);
     }
 }

--- a/src/main/java/com/destroystokyo/paper/world/PaperLightingQueue.java
+++ b/src/main/java/com/destroystokyo/paper/world/PaperLightingQueue.java
@@ -1,0 +1,104 @@
+package com.destroystokyo.paper.world;
+
+
+import co.aikar.timings.Timing;
+import com.destroystokyo.paper.MCUtil;
+import com.destroystokyo.paper.PaperMCConfig;
+import it.unimi.dsi.fastutil.objects.ObjectCollection;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.chunk.Chunk;
+
+import java.util.ArrayDeque;
+
+public class PaperLightingQueue {
+    private static final long MAX_TIME = (long) (1000000000 / 20 * 1.15);
+
+    public static void processQueue(long curTime) {
+        final long startTime = System.nanoTime();
+        final long maxTickTime = MAX_TIME - (startTime - curTime);
+
+        if (maxTickTime <= 0) {
+            return;
+        }
+
+        START:
+        for (World world : MinecraftServer.getServerInst().worlds) {
+            if (!PaperMCConfig.queueLightUpdates) {
+                continue;
+            }
+
+            ObjectCollection<Chunk> loadedChunks = ((WorldServer) world).getChunkProvider().id2ChunkMap.values();
+            for (Chunk chunk : loadedChunks.toArray(new Chunk[0])) {
+                if (chunk.lightingQueue.processQueue(startTime, maxTickTime)) {
+                    break START;
+                }
+            }
+        }
+    }
+
+    public static class LightingQueue extends ArrayDeque<Runnable> {
+        final private Chunk chunk;
+
+        public LightingQueue(Chunk chunk) {
+            super();
+            this.chunk = chunk;
+        }
+
+        /**
+         * Processes the lighting queue for this chunk
+         *
+         * @param startTime   If start Time is 0, we will not limit execution time
+         * @param maxTickTime Maximum time to spend processing lighting updates
+         * @return true to abort processing furthur lighting updates
+         */
+        public boolean processQueue(long startTime, long maxTickTime) {
+            if (this.isEmpty()) {
+                return false;
+            }
+            if (isOutOfTime(maxTickTime, startTime)) {
+
+            }
+            try (Timing ignored = chunk.world.timings.lightingQueueTimer.startTiming()) {
+                Runnable lightUpdate;
+                while ((lightUpdate = this.poll()) != null) {
+                    lightUpdate.run();
+                    if (isOutOfTime(maxTickTime, startTime)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * Flushes lighting updates to unload the chunk
+         */
+        public void processUnload() {
+            if (!PaperMCConfig.queueLightUpdates) {
+                return;
+            }
+            processQueue(0, 0); // No timeout
+
+            final int radius = 1;
+            for (int x = chunk.x - radius; x <= chunk.x + radius; ++x) {
+                for (int z = chunk.z - radius; z <= chunk.z + radius; ++z) {
+                    if (x == chunk.x && z == chunk.z) {
+                        continue;
+                    }
+
+                    Chunk neighbor = MCUtil.getLoadedChunkWithoutMarkingActive(chunk.world, x, z);
+                    if (neighbor != null) {
+                        neighbor.lightingQueue.processQueue(0, 0); // No timeout
+                    }
+                }
+            }
+        }
+
+        private static boolean isOutOfTime(long maxTickTime, long startTime) {
+            return startTime > 0 && System.nanoTime() - startTime > maxTickTime;
+        }
+    }
+}


### PR DESCRIPTION
Added paper light calculation optimizations:
> Server Patches - 0030-Lighting-Queue.patch
> Server Patches - 0077-Add-World-Util-Methods.patch (partially)
> Server Patches - 0078-Optimized-Light-Level-Comparisons.patch
> Server Patches - 0101-Do-not-load-chunks-for-light-checks.patch
> Server Patches - 0360-Backport-light-queue-changes-from-1.13.patch

Now testing on public server.
