### PR TITLE
Fix for fluids and feature for player connection

### DIFF
--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -181,7 +181,19 @@
                      return;
                  }
              }
-@@ -242,24 +320,33 @@
+@@ -226,7 +304,10 @@
+         this.field_147367_d.field_71304_b.func_76320_a("keepAlive");
+         long i = this.func_147363_d();
+ 
+-        if (i - this.field_194402_f >= 15000L)
++        // Mohist: add configurable timeout for player connections. Not always enough 15 seconds for full connection.
++        // e.g big mods like The Betweenlands or low end pc
++        //if (i - this.field_194402_f >= 15000L)
++        if (i - this.field_194402_f >= MohistConfig.instance.connectionTimeout.getValue())
+         {
+             if (this.field_194403_g)
+             {
+@@ -242,24 +323,33 @@
          }
  
          this.field_147367_d.field_71304_b.func_76319_b();
@@ -220,7 +232,7 @@
      {
          this.field_184349_l = this.field_147369_b.field_70165_t;
          this.field_184350_m = this.field_147369_b.field_70163_u;
-@@ -274,23 +361,48 @@
+@@ -274,23 +364,48 @@
          return this.field_147371_a;
      }
  
@@ -278,7 +290,7 @@
      }
  
      public void func_147358_a(CPacketInput p_147358_1_)
-@@ -345,9 +457,34 @@
+@@ -345,9 +460,34 @@
                  double d9 = entity.field_70159_w * entity.field_70159_w + entity.field_70181_x * entity.field_70181_x + entity.field_70179_y * entity.field_70179_y;
                  double d10 = d6 * d6 + d7 * d7 + d8 * d8;
  
@@ -316,7 +328,7 @@
                      this.field_147371_a.func_179290_a(new SPacketMoveVehicle(entity));
                      return;
                  }
-@@ -370,22 +507,90 @@
+@@ -370,22 +510,90 @@
                  d10 = d6 * d6 + d7 * d7 + d8 * d8;
                  boolean flag1 = false;
  
@@ -410,7 +422,7 @@
                  this.field_147367_d.func_184103_al().func_72358_d(this.field_147369_b);
                  this.field_147369_b.func_71000_j(this.field_147369_b.field_70165_t - d0, this.field_147369_b.field_70163_u - d1, this.field_147369_b.field_70161_v - d2);
                  this.field_184345_D = d11 >= -0.03125D && !this.field_147367_d.func_71231_X() && !worldserver.func_72829_c(entity.func_174813_aQ().func_186662_g(0.0625D).func_72321_a(0.0D, -0.55D, 0.0D));
-@@ -400,7 +605,7 @@
+@@ -400,7 +608,7 @@
      {
          PacketThreadUtil.func_180031_a(p_184339_1_, this, this.field_147369_b.func_71121_q());
  
@@ -419,7 +431,7 @@
          {
              this.field_147369_b.func_70080_a(this.field_184362_y.field_72450_a, this.field_184362_y.field_72448_b, this.field_184362_y.field_72449_c, this.field_147369_b.field_70177_z, this.field_147369_b.field_70125_A);
  
-@@ -459,7 +664,7 @@
+@@ -459,7 +667,7 @@
          {
              WorldServer worldserver = this.field_147367_d.func_71218_a(this.field_147369_b.field_71093_bK);
  
@@ -428,7 +440,7 @@
              {
                  if (this.field_147368_e == 0)
                  {
-@@ -473,6 +678,7 @@
+@@ -473,6 +681,7 @@
                          this.field_184343_A = this.field_147368_e;
                          this.func_147364_a(this.field_184362_y.field_72450_a, this.field_184362_y.field_72448_b, this.field_184362_y.field_72449_c, this.field_147369_b.field_70177_z, this.field_147369_b.field_70125_A);
                      }
@@ -436,7 +448,7 @@
                  }
                  else
                  {
-@@ -482,9 +688,17 @@
+@@ -482,9 +691,17 @@
                      {
                          this.field_147369_b.func_70080_a(this.field_147369_b.field_70165_t, this.field_147369_b.field_70163_u, this.field_147369_b.field_70161_v, p_147347_1_.func_186999_a(this.field_147369_b.field_70177_z), p_147347_1_.func_186998_b(this.field_147369_b.field_70125_A));
                          this.field_147367_d.func_184103_al().func_72358_d(this.field_147369_b);
@@ -454,7 +466,7 @@
                          double d0 = this.field_147369_b.field_70165_t;
                          double d1 = this.field_147369_b.field_70163_u;
                          double d2 = this.field_147369_b.field_70161_v;
-@@ -512,19 +726,34 @@
+@@ -512,19 +729,34 @@
                              ++this.field_184347_F;
                              int i = this.field_184347_F - this.field_184348_G;
  
@@ -493,7 +505,7 @@
                                      this.func_147364_a(this.field_147369_b.field_70165_t, this.field_147369_b.field_70163_u, this.field_147369_b.field_70161_v, this.field_147369_b.field_70177_z, this.field_147369_b.field_70125_A);
                                      return;
                                  }
-@@ -537,10 +766,15 @@
+@@ -537,10 +769,15 @@
  
                              if (this.field_147369_b.field_70122_E && !p_147347_1_.func_149465_i() && d8 > 0.0D)
                              {
@@ -510,7 +522,7 @@
                              this.field_147369_b.field_70122_E = p_147347_1_.func_149465_i();
                              double d12 = d8;
                              d7 = d4 - this.field_147369_b.field_70165_t;
-@@ -555,10 +789,9 @@
+@@ -555,10 +792,9 @@
                              d11 = d7 * d7 + d8 * d8 + d9 * d9;
                              boolean flag = false;
  
@@ -522,7 +534,7 @@
                              }
  
                              this.field_147369_b.func_70080_a(d4, d5, d6, f, f1);
-@@ -575,6 +808,69 @@
+@@ -575,6 +811,69 @@
                                  }
                              }
  
@@ -592,7 +604,7 @@
                              this.field_184344_B = d12 >= -0.03125D;
                              this.field_184344_B &= !this.field_147367_d.func_71231_X() && !this.field_147369_b.field_71075_bZ.field_75101_c;
                              this.field_184344_B &= !this.field_147369_b.func_70644_a(MobEffects.field_188424_y) && !this.field_147369_b.func_184613_cA() && !worldserver.func_72829_c(this.field_147369_b.func_174813_aQ().func_186662_g(0.0625D).func_72321_a(0.0D, -0.55D, 0.0D));
-@@ -596,25 +892,99 @@
+@@ -596,25 +895,99 @@
          this.func_175089_a(p_147364_1_, p_147364_3_, p_147364_5_, p_147364_7_, p_147364_8_, Collections.emptySet());
      }
  
@@ -702,7 +714,7 @@
          if (++this.field_184363_z == Integer.MAX_VALUE)
          {
              this.field_184363_z = 0;
-@@ -622,12 +992,13 @@
+@@ -622,12 +995,13 @@
  
          this.field_184343_A = this.field_147368_e;
          this.field_147369_b.func_70080_a(this.field_184362_y.field_72450_a, this.field_184362_y.field_72448_b, this.field_184362_y.field_72449_c, f, f1);
@@ -717,7 +729,7 @@
          WorldServer worldserver = this.field_147367_d.func_71218_a(this.field_147369_b.field_71093_bK);
          BlockPos blockpos = p_147345_1_.func_179715_a();
          this.field_147369_b.func_143004_u();
-@@ -639,7 +1010,16 @@
+@@ -639,7 +1013,16 @@
                  if (!this.field_147369_b.func_175149_v())
                  {
                      ItemStack itemstack = this.field_147369_b.func_184586_b(EnumHand.OFF_HAND);
@@ -735,7 +747,7 @@
                      this.field_147369_b.func_184611_a(EnumHand.MAIN_HAND, itemstack);
                  }
  
-@@ -648,6 +1028,20 @@
+@@ -648,6 +1031,20 @@
  
                  if (!this.field_147369_b.func_175149_v())
                  {
@@ -756,7 +768,7 @@
                      this.field_147369_b.func_71040_bB(false);
                  }
  
-@@ -671,7 +1065,10 @@
+@@ -671,7 +1068,10 @@
                  double d2 = this.field_147369_b.field_70161_v - ((double)blockpos.func_177952_p() + 0.5D);
                  double d3 = d0 * d0 + d1 * d1 + d2 * d2;
  
@@ -768,7 +780,7 @@
                  {
                      return;
                  }
-@@ -689,7 +1086,15 @@
+@@ -689,7 +1089,15 @@
                          }
                          else
                          {
@@ -784,7 +796,7 @@
                          }
                      }
                      else
-@@ -720,6 +1125,7 @@
+@@ -720,6 +1128,7 @@
      public void func_184337_a(CPacketPlayerTryUseItemOnBlock p_184337_1_)
      {
          PacketThreadUtil.func_180031_a(p_184337_1_, this, this.field_147369_b.func_71121_q());
@@ -792,7 +804,7 @@
          WorldServer worldserver = this.field_147367_d.func_71218_a(this.field_147369_b.field_71093_bK);
          EnumHand enumhand = p_184337_1_.func_187022_c();
          ItemStack itemstack = this.field_147369_b.func_184586_b(enumhand);
-@@ -729,8 +1135,17 @@
+@@ -729,8 +1138,17 @@
  
          if (blockpos.func_177956_o() < this.field_147367_d.func_71207_Z() - 1 || enumfacing != EnumFacing.UP && blockpos.func_177956_o() < this.field_147367_d.func_71207_Z())
          {
@@ -811,7 +823,7 @@
                  this.field_147369_b.field_71134_c.func_187251_a(this.field_147369_b, worldserver, itemstack, enumhand, blockpos, enumfacing, p_184337_1_.func_187026_d(), p_184337_1_.func_187025_e(), p_184337_1_.func_187020_f());
              }
          }
-@@ -748,6 +1163,7 @@
+@@ -748,6 +1166,7 @@
      public void func_147346_a(CPacketPlayerTryUseItem p_147346_1_)
      {
          PacketThreadUtil.func_180031_a(p_147346_1_, this, this.field_147369_b.func_71121_q());
@@ -819,7 +831,7 @@
          WorldServer worldserver = this.field_147367_d.func_71218_a(this.field_147369_b.field_71093_bK);
          EnumHand enumhand = p_147346_1_.func_187028_a();
          ItemStack itemstack = this.field_147369_b.func_184586_b(enumhand);
-@@ -755,7 +1171,46 @@
+@@ -755,7 +1174,46 @@
  
          if (!itemstack.func_190926_b())
          {
@@ -867,7 +879,7 @@
          }
      }
  
-@@ -767,7 +1222,8 @@
+@@ -767,7 +1225,8 @@
          {
              Entity entity = null;
  
@@ -877,7 +889,7 @@
              {
                  if (worldserver != null)
                  {
-@@ -784,42 +1240,17 @@
+@@ -784,42 +1243,17 @@
              {
                  this.field_147369_b.func_175399_e(this.field_147369_b);
                  this.field_147369_b.func_184210_p();
@@ -925,7 +937,7 @@
      }
  
      public void func_184340_a(CPacketSteerBoat p_184340_1_)
-@@ -835,13 +1266,26 @@
+@@ -835,13 +1269,26 @@
  
      public void func_147231_a(ITextComponent p_147231_1_)
      {
@@ -957,7 +969,7 @@
  
          if (this.field_147367_d.func_71264_H() && this.field_147369_b.func_70005_c_().equals(this.field_147367_d.func_71214_G()))
          {
-@@ -868,6 +1312,13 @@
+@@ -868,6 +1315,13 @@
              }
          }
  
@@ -971,7 +983,7 @@
          try
          {
              this.field_147371_a.func_179290_a(p_147359_1_);
-@@ -890,23 +1341,42 @@
+@@ -890,23 +1344,42 @@
      public void func_147355_a(CPacketHeldItemChange p_147355_1_)
      {
          PacketThreadUtil.func_180031_a(p_147355_1_, this, this.field_147369_b.func_71121_q());
@@ -1017,7 +1029,7 @@
          {
              TextComponentTranslation textcomponenttranslation = new TextComponentTranslation("chat.cannotSend", new Object[0]);
              textcomponenttranslation.func_150256_b().func_150238_a(TextFormatting.RED);
-@@ -922,45 +1392,273 @@
+@@ -922,45 +1395,273 @@
              {
                  if (!ChatAllowedCharacters.func_71566_a(s.charAt(i)))
                  {
@@ -1303,7 +1315,7 @@
          this.field_147369_b.func_143004_u();
  
          switch (p_147357_1_.func_180764_b())
-@@ -1042,8 +1740,16 @@
+@@ -1042,8 +1743,16 @@
      public void func_147340_a(CPacketUseEntity p_147340_1_)
      {
          PacketThreadUtil.func_180031_a(p_147340_1_, this, this.field_147369_b.func_71121_q());
@@ -1320,7 +1332,7 @@
          this.field_147369_b.func_143004_u();
  
          if (entity != null)
-@@ -1058,19 +1764,57 @@
+@@ -1058,19 +1767,57 @@
  
              if (this.field_147369_b.func_70068_e(entity) < d0)
              {
@@ -1379,7 +1391,7 @@
                      {
                          this.func_194028_b(new TextComponentTranslation("multiplayer.disconnect.invalid_entity_attacked", new Object[0]));
                          this.field_147367_d.func_71236_h("Player " + this.field_147369_b.func_70005_c_() + " tried to attack an invalid entity");
-@@ -1078,9 +1822,13 @@
+@@ -1078,9 +1825,13 @@
                      }
  
                      this.field_147369_b.func_71059_n(entity);
@@ -1394,7 +1406,7 @@
      }
  
      public void func_147342_a(CPacketClientStatus p_147342_1_)
-@@ -1106,7 +1854,7 @@
+@@ -1106,7 +1857,7 @@
                          return;
                      }
  
@@ -1403,7 +1415,7 @@
  
                      if (this.field_147367_d.func_71199_h())
                      {
-@@ -1124,17 +1872,21 @@
+@@ -1124,17 +1875,21 @@
      public void func_147356_a(CPacketCloseWindow p_147356_1_)
      {
          PacketThreadUtil.func_180031_a(p_147356_1_, this, this.field_147369_b.func_71121_q());
@@ -1427,7 +1439,7 @@
              {
                  NonNullList<ItemStack> nonnulllist = NonNullList.<ItemStack>func_191196_a();
  
-@@ -1147,10 +1899,294 @@
+@@ -1147,10 +1902,294 @@
              }
              else
              {
@@ -1724,7 +1736,7 @@
                      this.field_147369_b.field_71135_a.func_147359_a(new SPacketConfirmTransaction(p_147351_1_.func_149548_c(), p_147351_1_.func_149547_f(), true));
                      this.field_147369_b.field_71137_h = true;
                      this.field_147369_b.field_71070_bA.func_75142_b();
-@@ -1166,8 +2202,8 @@
+@@ -1166,8 +2205,8 @@
  
                      for (int j = 0; j < this.field_147369_b.field_71070_bA.field_75151_b.size(); ++j)
                      {
@@ -1735,7 +1747,7 @@
                          nonnulllist1.add(itemstack1);
                      }
  
-@@ -1191,6 +2227,7 @@
+@@ -1191,6 +2230,7 @@
      public void func_147338_a(CPacketEnchantItem p_147338_1_)
      {
          PacketThreadUtil.func_180031_a(p_147338_1_, this, this.field_147369_b.func_71121_q());
@@ -1743,7 +1755,7 @@
          this.field_147369_b.func_143004_u();
  
          if (this.field_147369_b.field_71070_bA.field_75152_c == p_147338_1_.func_149539_c() && this.field_147369_b.field_71070_bA.func_75129_b(this.field_147369_b) && !this.field_147369_b.func_175149_v())
-@@ -1230,8 +2267,46 @@
+@@ -1230,8 +2270,46 @@
              }
  
              boolean flag1 = p_147344_1_.func_149627_c() >= 1 && p_147344_1_.func_149627_c() <= 45;
@@ -1791,7 +1803,7 @@
              if (flag1 && flag2)
              {
                  if (itemstack.func_190926_b())
-@@ -1261,6 +2336,7 @@
+@@ -1261,6 +2339,7 @@
      public void func_147339_a(CPacketConfirmTransaction p_147339_1_)
      {
          PacketThreadUtil.func_180031_a(p_147339_1_, this, this.field_147369_b.func_71121_q());
@@ -1799,7 +1811,7 @@
          Short oshort = this.field_147372_n.func_76041_a(this.field_147369_b.field_71070_bA.field_75152_c);
  
          if (oshort != null && p_147339_1_.func_149533_d() == oshort.shortValue() && this.field_147369_b.field_71070_bA.field_75152_c == p_147339_1_.func_149532_c() && !this.field_147369_b.field_71070_bA.func_75129_b(this.field_147369_b) && !this.field_147369_b.func_175149_v())
-@@ -1272,6 +2348,7 @@
+@@ -1272,6 +2351,7 @@
      public void func_147343_a(CPacketUpdateSign p_147343_1_)
      {
          PacketThreadUtil.func_180031_a(p_147343_1_, this, this.field_147369_b.func_71121_q());
@@ -1807,7 +1819,7 @@
          this.field_147369_b.func_143004_u();
          WorldServer worldserver = this.field_147367_d.func_71218_a(this.field_147369_b.field_71093_bK);
          BlockPos blockpos = p_147343_1_.func_179722_a();
-@@ -1288,19 +2365,35 @@
+@@ -1288,19 +2368,35 @@
  
              TileEntitySign tileentitysign = (TileEntitySign)tileentity;
  
@@ -1845,7 +1857,7 @@
              tileentitysign.func_70296_d();
              worldserver.func_184138_a(blockpos, iblockstate, iblockstate, 3);
          }
-@@ -1316,7 +2409,11 @@
+@@ -1316,7 +2412,11 @@
          }
          else if (!this.field_147369_b.func_70005_c_().equals(this.field_147367_d.func_71214_G()))
          {
@@ -1858,7 +1870,7 @@
          }
      }
  
-@@ -1328,20 +2425,28 @@
+@@ -1328,20 +2428,28 @@
      public void func_147348_a(CPacketPlayerAbilities p_147348_1_)
      {
          PacketThreadUtil.func_180031_a(p_147348_1_, this, this.field_147369_b.func_71121_q());
@@ -1895,7 +1907,7 @@
      }
  
      public void func_147352_a(CPacketClientSettings p_147352_1_)
-@@ -1357,6 +2462,11 @@
+@@ -1357,6 +2465,11 @@
  
          if ("MC|BEdit".equals(s))
          {
@@ -1907,7 +1919,7 @@
              PacketBuffer packetbuffer = p_147349_1_.func_180760_b();
  
              try
-@@ -1383,15 +2493,22 @@
+@@ -1383,15 +2496,22 @@
                  if (itemstack.func_77973_b() == Items.field_151099_bA && itemstack.func_77973_b() == itemstack1.func_77973_b())
                  {
                      itemstack1.func_77983_a("pages", itemstack.func_77978_p().func_150295_c("pages", 8));
@@ -1930,7 +1942,7 @@
              PacketBuffer packetbuffer1 = p_147349_1_.func_180760_b();
  
              try
-@@ -1431,12 +2548,14 @@
+@@ -1431,12 +2551,14 @@
                      }
  
                      itemstack2.func_77983_a("pages", nbttaglist);
@@ -1946,7 +1958,7 @@
              }
          }
          else if ("MC|TrSel".equals(s))
-@@ -1454,6 +2573,7 @@
+@@ -1454,6 +2576,7 @@
              catch (Exception exception5)
              {
                  field_147370_c.error("Couldn't select trade", (Throwable)exception5);
@@ -1954,7 +1966,7 @@
              }
          }
          else if ("MC|AdvCmd".equals(s))
-@@ -1516,6 +2636,7 @@
+@@ -1516,6 +2639,7 @@
              catch (Exception exception4)
              {
                  field_147370_c.error("Couldn't set command block", (Throwable)exception4);
@@ -1962,7 +1974,7 @@
              }
          }
          else if ("MC|AutoCmd".equals(s))
-@@ -1594,6 +2715,7 @@
+@@ -1594,6 +2718,7 @@
              catch (Exception exception3)
              {
                  field_147370_c.error("Couldn't set command block", (Throwable)exception3);
@@ -1970,7 +1982,7 @@
              }
          }
          else if ("MC|Beacon".equals(s))
-@@ -1620,6 +2742,7 @@
+@@ -1620,6 +2745,7 @@
                  catch (Exception exception2)
                  {
                      field_147370_c.error("Couldn't set beacon", (Throwable)exception2);
@@ -1978,7 +1990,7 @@
                  }
              }
          }
-@@ -1731,6 +2854,7 @@
+@@ -1731,6 +2857,7 @@
              catch (Exception exception1)
              {
                  field_147370_c.error("Couldn't set structure block", (Throwable)exception1);
@@ -1986,7 +1998,7 @@
              }
          }
          else if ("MC|PickItem".equals(s))
-@@ -1748,7 +2872,26 @@
+@@ -1748,7 +2875,26 @@
              catch (Exception exception)
              {
                  field_147370_c.error("Couldn't pick item", (Throwable)exception);

--- a/src/main/java/com/mohistmc/configuration/MohistConfig.java
+++ b/src/main/java/com/mohistmc/configuration/MohistConfig.java
@@ -107,6 +107,8 @@ public class MohistConfig extends ConfigBase {
     /* ======================================================================== */
     public List<Integer> dimensionsNotLoaded = new ArrayList();
 
+    public final IntSetting connectionTimeout = new IntSetting(this, "mohist.connectionTimeout", 15000);
+
     public MohistConfig() {
         super("mohist.yml");
         init();

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -32,10 +32,7 @@ import net.minecraft.item.ItemBucket;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
-import net.minecraft.util.SoundCategory;
-import net.minecraft.util.SoundEvent;
+import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeModContainer;
@@ -48,6 +45,9 @@ import net.minecraftforge.fluids.capability.wrappers.FluidBlockWrapper;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
+import org.bukkit.craftbukkit.v1_12_R1.event.CraftEventFactory;
+import org.bukkit.event.player.PlayerBucketEmptyEvent;
+import org.bukkit.event.player.PlayerBucketFillEvent;
 
 public class FluidUtil
 {
@@ -566,6 +566,16 @@ public class FluidUtil
 
         if (block instanceof IFluidBlock || block instanceof BlockLiquid)
         {
+            // Mohist: calling bukkit event before pickup custom fluid
+            if (playerIn != null) {
+                // Send default empty bucket
+                PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent(
+                        playerIn, pos.getX(), pos.getY(), pos.getZ(), null, emptyContainer.copy(), Items.BUCKET);
+                // Changes from event not handled, only canceling
+                if (event.isCancelled()) {
+                    return FluidActionResult.FAILURE;
+                }
+            }
             IFluidHandler targetFluidHandler = getFluidHandler(worldIn, pos, side);
             if (targetFluidHandler != null)
             {
@@ -618,6 +628,16 @@ public class FluidUtil
         if (world == null || resource == null || pos == null)
         {
             return false;
+        }
+
+        // Mohist: calling bukkit event before place custom fluid
+        if (player != null) {
+            PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(
+                    player, pos.getX(), pos.getY(), pos.getZ(), null, player.getHeldItem(EnumHand.MAIN_HAND).copy());
+            // Changes from event not handled, only canceling
+            if (event.isCancelled()) {
+                return false;
+            }
         }
 
         Fluid fluid = resource.getFluid();

--- a/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
+++ b/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
@@ -46,6 +46,8 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.items.ItemHandlerHelper;
+import org.bukkit.craftbukkit.v1_12_R1.event.CraftEventFactory;
+import org.bukkit.event.player.PlayerBucketFillEvent;
 
 /**
  * A universal bucket that can hold any liquid
@@ -213,6 +215,23 @@ public class UniversalBucket extends Item
     {
         if (event.getResult() != Event.Result.DEFAULT)
         {
+            // Mohist: checking when result is ALLOW
+            if (event.getResult() == Event.Result.ALLOW) {
+                if (event.getEntityPlayer() != null) {
+                    RayTraceResult target = event.getTarget();
+                    if (target != null) {
+                        BlockPos pos = target.getBlockPos();
+                        PlayerBucketFillEvent bEvent = CraftEventFactory.callPlayerBucketFillEvent(
+                                event.getEntityPlayer(), pos.getX(), pos.getY(), pos.getZ(), null,
+                                event.getEntityPlayer().getHeldItemMainhand().copy(), Items.BUCKET);
+                        // Changes from event not handled, only canceling
+                        if (bEvent.isCancelled()) {
+                            event.setCanceled(true);
+                            event.setResult(Event.Result.DENY);
+                        }
+                    }
+                }
+            }
             // event was already handled
             return;
         }


### PR DESCRIPTION
Now custom fluids and universal bucket calling Bukkit events when placed or picked.
Not for all mods, only for mods that use forge fluid api.

Added custom connection timeout in mohist config.
Not always enough 15 seconds for full connection. (e.g my modpack cannot complete full initialization on low end PC)

Now testing on public server.
Tested on localhost server.